### PR TITLE
Fix `hassfest` validation error

### DIFF
--- a/custom_components/watersmart/config_flow.py
+++ b/custom_components/watersmart/config_flow.py
@@ -87,7 +87,13 @@ class WaterSmartConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
                 return self.async_create_entry(title=info["title"], data=user_input)
 
         return self.async_show_form(
-            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+            step_id="user",
+            data_schema=STEP_USER_DATA_SCHEMA,
+            errors=errors,
+            description_placeholders={
+                "example_host": "bendoregon",
+                "example_url": "https://bendoregon.watersmart.com/",
+            },
         )
 
 

--- a/custom_components/watersmart/translations/en.json
+++ b/custom_components/watersmart/translations/en.json
@@ -15,7 +15,7 @@
                     "password": "Password",
                     "username": "Username"
                 },
-                "description": "Enter your host and credentials. The host is the subdomain for accessing Watersmart, i.e. `bendoregon` for https://bendoregon.watersmart.com/.",
+                "description": "Enter your host and credentials. The host is the subdomain for accessing Watersmart, i.e. `{example_host}` for {example_url}.",
                 "title": "Subdomain & Authentication"
             }
         }


### PR DESCRIPTION
The error was:

> Invalid translations/en.json: the string should not contain URLs, please use description placeholders instead for dictionary value @ data['config']['step']['user']['description'].