### PR TITLE
Add historical statistics import and energy dashboard sensor

### DIFF
--- a/custom_components/watersmart/client.py
+++ b/custom_components/watersmart/client.py
@@ -155,7 +155,7 @@ class WaterSmartClient:
         errors = [error.text.strip() for error in soup.select(".error-message")]
         errors = [error for error in errors if error]
 
-        if len(errors):
+        if errors:
             raise AuthenticationError(errors)
 
         account = _assert_node(

--- a/custom_components/watersmart/const.py
+++ b/custom_components/watersmart/const.py
@@ -15,3 +15,4 @@ class SensorKey(StrEnum):
 
     GALLONS_FOR_MOST_RECENT_HOUR = auto()
     GALLONS_FOR_MOST_RECENT_FULL_DAY_KEY = auto()
+    TOTAL_HOURLY_USAGE = auto()

--- a/custom_components/watersmart/coordinator.py
+++ b/custom_components/watersmart/coordinator.py
@@ -169,8 +169,8 @@ class WaterSmartUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
 
         if last_stats and statistic_id in last_stats:
             last_stat = last_stats[statistic_id][0]
-            last_timestamp = last_stat["start"]  # already a Unix float timestamp
-            running_sum = last_stat.get("sum") or 0.0
+            last_timestamp = float(last_stat["start"])
+            running_sum = last_stat.get("sum") if last_stat.get("sum") is not None else 0.0
 
         new_records = [
             r for r in records

--- a/custom_components/watersmart/coordinator.py
+++ b/custom_components/watersmart/coordinator.py
@@ -128,7 +128,7 @@ class WaterSmartUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
                     "state": total,
                     "attrs": {},
                 }
-        except Exception:  # noqa: BLE001
+        except Exception:
             _LOGGER.warning("Failed to import statistics", exc_info=True)
 
         return result
@@ -160,7 +160,7 @@ class WaterSmartUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
         # Find the last imported record so we only push new data.
         last_stats = await recorder_instance.async_add_executor_job(
             functools.partial(
-                get_last_statistics, self.hass, 1, statistic_id, False, {"sum"}
+                get_last_statistics, self.hass, 1, statistic_id, convert_units=False, types={"sum"}
             )
         )
 

--- a/custom_components/watersmart/coordinator.py
+++ b/custom_components/watersmart/coordinator.py
@@ -5,10 +5,19 @@ from collections.abc import Callable
 import datetime as dt
 import functools
 import logging
+import re
 from typing import Any, Protocol, TypedDict, cast
 
 from aiohttp.client_exceptions import ClientConnectorError
+from homeassistant.components.recorder import get_instance
+from homeassistant.components.recorder.models import StatisticData, StatisticMetaData
+from homeassistant.components.recorder.statistics import (
+    async_add_external_statistics,
+    get_last_statistics,
+)
+from homeassistant.const import UnitOfVolume
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util.dt import as_local, get_default_time_zone, start_of_local_day
@@ -22,11 +31,29 @@ EXCEPTIONS = (AuthenticationError, ClientConnectorError)
 _LOGGER = logging.getLogger(__name__)
 
 
+def _to_statistic_slug(value: str) -> str:
+    """Convert a string to a valid statistic ID slug.
+
+    Replaces any character not in [a-z0-9] with an underscore, collapses
+    consecutive underscores, and strips leading/trailing underscores.
+
+    Args:
+        value: The raw string to convert.
+
+    Returns:
+        A slug containing only [a-z0-9_], with no leading/trailing/double underscores.
+    """
+    slug = re.sub(r"[^a-z0-9]", "_", value.lower())
+    slug = re.sub(r"_+", "_", slug)
+    return slug.strip("_")
+
+
 class CoordinatorData(TypedDict, total=False):
     """Shape of coordinator data."""
 
     gallons_for_most_recent_hour: SensorData
     gallons_for_most_recent_full_day: SensorData
+    total_hourly_usage: SensorData
     hourly: list[UsageRecord]
 
 
@@ -91,7 +118,94 @@ class WaterSmartUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
 
         _LOGGER.debug("Async update complete")
 
+        # Import statistics outside the API timeout block so a large initial
+        # backfill doesn't race against the 30-second fetch timeout.
+        # Errors here are non-fatal — sensor data is still valid without statistics.
+        try:
+            total = await self._async_import_statistics(result["hourly"])
+            if total is not None:
+                cast("dict[str, SensorData]", result)[SensorKey.TOTAL_HOURLY_USAGE] = {
+                    "state": total,
+                    "attrs": {},
+                }
+        except Exception:  # noqa: BLE001
+            _LOGGER.warning("Failed to import statistics", exc_info=True)
+
         return result
+
+    async def _async_import_statistics(
+        self,
+        records: list[UsageRecord],
+    ) -> float | None:
+        """Import hourly usage statistics into HA recorder.
+
+        On first call, imports the full historical record set. On subsequent
+        calls, only records newer than the last imported timestamp are added.
+
+        Args:
+            records: All hourly usage records returned by the API.
+
+        Returns:
+            The cumulative running sum of gallons, or None if the recorder is
+            unavailable.
+        """
+        try:
+            recorder_instance = get_instance(self.hass)
+        except (HomeAssistantError, KeyError):
+            _LOGGER.debug("Recorder not available, skipping statistics import")
+            return None
+
+        statistic_id = f"{DOMAIN}:{_to_statistic_slug(self.hostname)}_hourly_usage"
+
+        # Find the last imported record so we only push new data.
+        last_stats = await recorder_instance.async_add_executor_job(
+            functools.partial(
+                get_last_statistics, self.hass, 1, statistic_id, False, {"sum"}
+            )
+        )
+
+        last_timestamp: float | None = None
+        running_sum: float = 0.0
+
+        if last_stats and statistic_id in last_stats:
+            last_stat = last_stats[statistic_id][0]
+            last_timestamp = last_stat["start"]  # already a Unix float timestamp
+            running_sum = last_stat.get("sum") or 0.0
+
+        new_records = [
+            r for r in records
+            if last_timestamp is None or r["read_datetime"] > last_timestamp
+        ]
+
+        if not new_records:
+            return running_sum
+
+        _LOGGER.debug("Importing %d new statistics records", len(new_records))
+
+        stat_data: list[StatisticData] = []
+        for record in new_records:
+            gallons = _record_gallons(record)
+            running_sum += gallons
+            start = dt.datetime.fromtimestamp(record["read_datetime"], tz=dt.UTC)
+            stat_data.append(
+                StatisticData(
+                    start=start,
+                    mean=gallons,
+                    sum=running_sum,
+                )
+            )
+
+        metadata = StatisticMetaData(
+            has_mean=True,
+            has_sum=True,
+            name=f"WaterSmart {self.hostname} Hourly Usage",
+            source=DOMAIN,
+            statistic_id=statistic_id,
+            unit_of_measurement=UnitOfVolume.GALLONS,
+        )
+
+        async_add_external_statistics(self.hass, metadata, stat_data)
+        return running_sum
 
 
 def _get_device_info(hostname: str, username: str) -> DeviceInfo:

--- a/custom_components/watersmart/manifest.json
+++ b/custom_components/watersmart/manifest.json
@@ -1,11 +1,11 @@
 {
   "domain": "watersmart",
   "name": "WaterSmart",
+  "after_dependencies": ["recorder"],
   "codeowners": [
     "@wbyoung"
   ],
   "config_flow": true,
-  "after_dependencies": ["recorder"],
   "dependencies": [],
   "documentation": "https://github.com/wbyoung/watersmart",
   "homekit": {},

--- a/custom_components/watersmart/manifest.json
+++ b/custom_components/watersmart/manifest.json
@@ -5,6 +5,7 @@
     "@wbyoung"
   ],
   "config_flow": true,
+  "after_dependencies": ["recorder"],
   "dependencies": [],
   "documentation": "https://github.com/wbyoung/watersmart",
   "homekit": {},

--- a/custom_components/watersmart/sensor.py
+++ b/custom_components/watersmart/sensor.py
@@ -8,6 +8,7 @@ from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
+    SensorStateClass,
 )
 from homeassistant.const import UnitOfVolume
 from homeassistant.core import HomeAssistant, callback
@@ -42,6 +43,14 @@ SENSOR_TYPES: tuple[WaterSmartSensorDescription, ...] = (
         device_class=SensorDeviceClass.WATER,
         native_unit_of_measurement=UnitOfVolume.GALLONS,
         translation_key="gallons_for_most_recent_full_day",
+    ),
+    WaterSmartSensorDescription(
+        key=SensorKey.TOTAL_HOURLY_USAGE,
+        value_fn=lambda data: cast("float", data),
+        device_class=SensorDeviceClass.WATER,
+        native_unit_of_measurement=UnitOfVolume.GALLONS,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        translation_key="total_hourly_usage",
     ),
 )
 
@@ -112,4 +121,6 @@ class WaterSmartSensor(CoordinatorEntity[WaterSmartUpdateCoordinator], SensorEnt
         Returns:
             The actual sensor data.
         """
-        return cast("dict[str, SensorData]", coordinator_data)[kind]
+        return cast("dict[str, SensorData]", coordinator_data).get(
+            kind, {"state": None, "attrs": {}}
+        )

--- a/custom_components/watersmart/translations/en.json
+++ b/custom_components/watersmart/translations/en.json
@@ -29,7 +29,7 @@
                 "name": "Most recent hour usage"
             },
             "total_hourly_usage": {
-                "name": "Total usage"
+                "name": "Cumulative water usage"
             }
         }
     },

--- a/custom_components/watersmart/translations/en.json
+++ b/custom_components/watersmart/translations/en.json
@@ -27,6 +27,9 @@
             },
             "gallons_for_most_recent_hour": {
                 "name": "Most recent hour usage"
+            },
+            "total_hourly_usage": {
+                "name": "Total usage"
             }
         }
     },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,5 @@
 [project]
+name = "watersmart"
 requires-python = ">=3.13"
 
 [tool.coverage.run]
@@ -133,6 +134,9 @@ split-on-trailing-comma = false
 ".github/*.py" = [
   "ANN",      # flake8-annotations
   "INP001",   # file {filename} is part of an implicit namespace package. Add an __init__.py
+  ]
+"custom_components/watersmart/__init__.py" = [
+  "RUF067",   # HA integration __init__.py intentionally contains setup functions, not just re-exports
   ]
 "tests/**" = [
   "ANN001",   # missing type annotation for function argument {name}

--- a/tests/snapshots/test_sensor.ambr
+++ b/tests/snapshots/test_sensor.ambr
@@ -110,7 +110,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '1135.6235352',
+    'state': '1135.6',
   })
 # ---
 # name: test_most_recent_hour_sensor
@@ -145,7 +145,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '54.1313885112',
+    'state': '54.1',
   })
 # ---
 # name: test_most_recent_hour_sensor_with_none_in_data
@@ -259,7 +259,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '1056.129887736',
+    'state': '1056.1',
   })
 # ---
 # name: test_sensors_for_zero_gallons
@@ -277,7 +277,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.0',
+    'state': '0',
   })
 # ---
 # name: test_sensors_for_zero_gallons.1
@@ -312,6 +312,6 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.0',
+    'state': '0',
   })
 # ---

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,390 @@
+"""Test the WaterSmart update coordinator."""
+
+import datetime as dt
+import functools
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.components.recorder.statistics import (
+    get_last_statistics,
+    statistics_during_period,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.loader import DATA_CUSTOM_COMPONENTS
+import pytest
+from pytest_homeassistant_custom_component.components.recorder.common import (
+    async_wait_recording_done,
+)
+
+from custom_components.watersmart.const import DOMAIN
+from custom_components.watersmart.coordinator import _to_statistic_slug  # noqa: PLC2701
+
+STATISTIC_ID = f"{DOMAIN}:test_hourly_usage"
+
+# Timestamps and gallons from realtime_api_response.json
+_T1, _T2, _T3, _T4 = 1718823600, 1718827200, 1718830800, 1718834400
+#   gallons:  7.48       0          7.48       0
+
+
+@pytest.mark.parametrize(
+    ("hostname", "expected_slug"),
+    [
+        ("test", "test"),                             # baseline used throughout tests
+        ("mywater.smart.com", "mywater_smart_com"),   # dots → underscores
+        ("MY-UTILITY.COM", "my_utility_com"),         # uppercase lowercased, hyphens → underscores
+        ("double--dash", "double_dash"),              # consecutive specials collapsed
+        ("-leading-trailing-", "leading_trailing"),   # leading/trailing underscores stripped
+        ("123abc", "123abc"),                         # leading digits are valid
+    ],
+)
+def test_to_statistic_slug(hostname: str, expected_slug: str) -> None:
+    """_to_statistic_slug produces a stable, valid slug for real-world hostnames.
+
+    The slug is embedded in the permanent statistic ID stored in the HA recorder;
+    an incorrect mapping would orphan historical water-usage data under the wrong key.
+    """
+    assert _to_statistic_slug(hostname) == expected_slug
+
+
+# Override the conftest autouse fixture so it does not force `hass` to be
+# created before recorder fixtures (which must run first).  Custom-integration
+# enablement is handled manually inside _init instead.
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations():
+    """No-op override - custom integrations are enabled inside _init."""
+
+
+async def _init(hass, mock_config_entry):
+    """Set up the WaterSmart integration (mirrors the init_integration fixture)."""
+    hass.data.pop(DATA_CUSTOM_COMPONENTS, None)  # enable custom integrations
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+
+async def test_statistics_full_backfill(
+    hass: HomeAssistant,
+    mock_config_entry,
+    mock_sensor_name,
+    mock_watersmart_client,
+):
+    """All records are imported and summed correctly on first run."""
+    mock_recorder = MagicMock()
+    mock_recorder.async_add_executor_job = AsyncMock(return_value={})
+
+    with (
+        patch(
+            "custom_components.watersmart.coordinator.get_instance",
+            return_value=mock_recorder,
+        ),
+        patch(
+            "custom_components.watersmart.coordinator.async_add_external_statistics"
+        ) as mock_add,
+    ):
+        await _init(hass, mock_config_entry)
+
+        assert mock_add.call_count == 1
+        _, metadata, stat_data = mock_add.call_args.args
+
+        assert metadata["statistic_id"] == STATISTIC_ID
+        assert metadata["has_sum"] is True
+
+        assert len(stat_data) == 4
+
+        assert stat_data[0]["start"] == dt.datetime(2024, 6, 19, 19, 0, tzinfo=dt.UTC)
+        assert stat_data[0]["mean"] == pytest.approx(7.48)
+        assert stat_data[0]["sum"] == pytest.approx(7.48)
+
+        assert stat_data[1]["start"] == dt.datetime(2024, 6, 19, 20, 0, tzinfo=dt.UTC)
+        assert stat_data[1]["mean"] == 0
+        assert stat_data[1]["sum"] == pytest.approx(7.48)
+
+        assert stat_data[2]["start"] == dt.datetime(2024, 6, 19, 21, 0, tzinfo=dt.UTC)
+        assert stat_data[2]["mean"] == pytest.approx(7.48)
+        assert stat_data[2]["sum"] == pytest.approx(14.96)
+
+        assert stat_data[3]["start"] == dt.datetime(2024, 6, 19, 22, 0, tzinfo=dt.UTC)
+        assert stat_data[3]["mean"] == 0
+        assert stat_data[3]["sum"] == pytest.approx(14.96)
+
+        total_sensor = hass.states.get(
+            "sensor.watersmart_test_total_hourly_usage"
+        )
+        assert total_sensor.state not in {"unknown", "unavailable"}
+
+
+async def test_statistics_incremental_import(
+    hass: HomeAssistant,
+    mock_config_entry,
+    mock_sensor_name,
+    mock_watersmart_client,
+):
+    """Only records newer than the last stored statistic are imported."""
+    last_stats = {STATISTIC_ID: [{"start": float(_T2), "sum": 7.48}]}
+
+    mock_recorder = MagicMock()
+    mock_recorder.async_add_executor_job = AsyncMock(return_value=last_stats)
+
+    with (
+        patch(
+            "custom_components.watersmart.coordinator.get_instance",
+            return_value=mock_recorder,
+        ),
+        patch(
+            "custom_components.watersmart.coordinator.async_add_external_statistics"
+        ) as mock_add,
+    ):
+        await _init(hass, mock_config_entry)
+
+        assert mock_add.call_count == 1
+        _, _metadata, stat_data = mock_add.call_args.args
+
+        # Only records 3 and 4 (timestamps > _T2) should be imported.
+        assert len(stat_data) == 2
+
+        assert stat_data[0]["start"] == dt.datetime(2024, 6, 19, 21, 0, tzinfo=dt.UTC)
+        assert stat_data[0]["mean"] == pytest.approx(7.48)
+        assert stat_data[0]["sum"] == pytest.approx(14.96)  # prior 7.48 + 7.48
+
+        assert stat_data[1]["start"] == dt.datetime(2024, 6, 19, 22, 0, tzinfo=dt.UTC)
+        assert stat_data[1]["mean"] == 0
+        assert stat_data[1]["sum"] == pytest.approx(14.96)
+
+
+async def test_statistics_no_new_records(
+    hass: HomeAssistant,
+    mock_config_entry,
+    mock_sensor_name,
+    mock_watersmart_client,
+):
+    """No statistics are pushed when all records are already stored."""
+    last_stats = {STATISTIC_ID: [{"start": float(_T4), "sum": 14.96}]}
+
+    mock_recorder = MagicMock()
+    mock_recorder.async_add_executor_job = AsyncMock(return_value=last_stats)
+
+    with (
+        patch(
+            "custom_components.watersmart.coordinator.get_instance",
+            return_value=mock_recorder,
+        ),
+        patch(
+            "custom_components.watersmart.coordinator.async_add_external_statistics"
+        ) as mock_add,
+    ):
+        await _init(hass, mock_config_entry)
+
+        mock_add.assert_not_called()
+
+
+async def test_statistics_zero_prior_sum_preserved(
+    hass: HomeAssistant,
+    mock_config_entry,
+    mock_sensor_name,
+    mock_watersmart_client,
+):
+    """A prior sum of 0.0 is not treated as falsy when resuming the running total."""
+    last_stats = {STATISTIC_ID: [{"start": float(_T2), "sum": 0.0}]}
+
+    mock_recorder = MagicMock()
+    mock_recorder.async_add_executor_job = AsyncMock(return_value=last_stats)
+
+    with (
+        patch(
+            "custom_components.watersmart.coordinator.get_instance",
+            return_value=mock_recorder,
+        ),
+        patch(
+            "custom_components.watersmart.coordinator.async_add_external_statistics"
+        ) as mock_add,
+    ):
+        await _init(hass, mock_config_entry)
+
+        _, _metadata, stat_data = mock_add.call_args.args
+
+        # Records 3 and 4 imported; running sum starts from 0.0, not a fallback default.
+        assert len(stat_data) == 2
+        assert stat_data[0]["sum"] == pytest.approx(7.48)   # 0.0 + 7.48
+        assert stat_data[1]["sum"] == pytest.approx(7.48)   # + 0
+
+
+@pytest.mark.parametrize("error", [HomeAssistantError, KeyError])
+async def test_statistics_recorder_unavailable(
+    hass: HomeAssistant,
+    mock_config_entry,
+    mock_sensor_name,
+    mock_watersmart_client,
+    error,
+):
+    """Statistics import is silently skipped when the recorder is unavailable."""
+    with (
+        patch(
+            "custom_components.watersmart.coordinator.get_instance",
+            side_effect=error,
+        ),
+        patch(
+            "custom_components.watersmart.coordinator.async_add_external_statistics"
+        ) as mock_add,
+    ):
+        await _init(hass, mock_config_entry)
+
+        mock_add.assert_not_called()
+
+        # Non-statistics sensors must still be functional even without the recorder.
+        recent_hour = hass.states.get(
+            "sensor.watersmart_test_gallons_for_most_recent_hour"
+        )
+        assert recent_hour is not None
+        assert recent_hour.state not in {"unknown", "unavailable"}
+
+        total_sensor = hass.states.get(
+            "sensor.watersmart_test_total_hourly_usage"
+        )
+        assert total_sensor.state == "unknown"
+
+
+async def test_statistics_recorder_contains_historical_data(
+    recorder_mock,
+    hass: HomeAssistant,
+    mock_config_entry,
+    mock_sensor_name,
+    mock_watersmart_client,
+):
+    """On first setup, the HA recorder contains statistic ID watersmart:<hostname>_hourly_usage.
+
+    Historical data goes back to the earliest available API record.
+    """
+    await _init(hass, mock_config_entry)
+    await async_wait_recording_done(hass)
+
+    # Verify the statistic ID exists and the final running sum is correct.
+    last = await recorder_mock.async_add_executor_job(
+        functools.partial(
+            get_last_statistics, hass, 1, STATISTIC_ID, convert_units=False, types={"sum"}
+        )
+    )
+    assert STATISTIC_ID in last
+    assert last[STATISTIC_ID][0]["sum"] == pytest.approx(14.96)  # 7.48 + 0 + 7.48 + 0
+
+    # Verify all historical records were written, starting from the earliest.
+    all_stats = await recorder_mock.async_add_executor_job(
+        functools.partial(
+            statistics_during_period,
+            hass,
+            dt.datetime(2024, 6, 19, 0, 0, tzinfo=dt.UTC),
+            None,
+            {STATISTIC_ID},
+            "hour",
+            None,
+            {"sum"},
+        )
+    )
+    assert STATISTIC_ID in all_stats
+    rows = all_stats[STATISTIC_ID]
+    assert len(rows) == 4
+    assert float(rows[0]["start"]) == pytest.approx(float(_T1))  # earliest record
+
+
+async def test_total_usage_sensor_selectable_in_energy_dashboard(
+    recorder_mock,
+    hass: HomeAssistant,
+    mock_config_entry,
+    mock_sensor_name,
+    mock_watersmart_client,
+):
+    """The total_hourly_usage sensor must have a valid state and the correct attributes.
+
+    Ensures it appears as a selectable entity (not 'entity without state') in the
+    Energy Dashboard -> Water consumption configuration panel.
+    """
+    await _init(hass, mock_config_entry)
+    await async_wait_recording_done(hass)
+
+    sensor = hass.states.get("sensor.watersmart_test_total_hourly_usage")
+    assert sensor is not None
+    # A state of "unknown" or "unavailable" causes the Energy Dashboard to show
+    # the entity as "entity without state" rather than as a usable data source.
+    assert sensor.state not in {"unknown", "unavailable"}
+    # These two attributes determine eligibility in the Energy Dashboard water picker.
+    assert sensor.attributes["device_class"] == "water"
+    assert sensor.attributes["state_class"] == "total_increasing"
+
+
+async def test_statistics_incremental_append_to_recorder(
+    recorder_mock,
+    hass: HomeAssistant,
+    mock_config_entry,
+    mock_sensor_name,
+    mock_watersmart_client,
+):
+    """On subsequent refreshes, only new records are appended to the recorder."""
+    t5 = _T4 + 3600  # one hour after the last fixture record
+
+    # First refresh: import the initial 4 records.
+    await _init(hass, mock_config_entry)
+    await async_wait_recording_done(hass)
+
+    # Simulate a new API record appearing since the last refresh.
+    original_data = mock_watersmart_client.async_get_hourly_data.return_value
+    new_record = {"read_datetime": t5, "gallons": 5.0, "flags": None, "leak_gallons": 0}
+    mock_watersmart_client.async_get_hourly_data.return_value = [*original_data, new_record]
+
+    # Trigger a second coordinator refresh.
+    coordinator = hass.data[DOMAIN][mock_config_entry.entry_id].coordinator
+    await coordinator.async_refresh()
+    await async_wait_recording_done(hass)
+
+    # Only the new record is appended: 5 rows total, not 4+5=9 from a full re-import.
+    all_stats = await recorder_mock.async_add_executor_job(
+        functools.partial(
+            statistics_during_period,
+            hass,
+            dt.datetime(2024, 6, 19, 0, 0, tzinfo=dt.UTC),
+            None,
+            {STATISTIC_ID},
+            "hour",
+            None,
+            {"sum"},
+        )
+    )
+    assert STATISTIC_ID in all_stats
+    rows = all_stats[STATISTIC_ID]
+    assert len(rows) == 5  # 4 original + 1 new
+
+    # The final running sum should be 14.96 + 5.0 = 19.96.
+    last = await recorder_mock.async_add_executor_job(
+        functools.partial(
+            get_last_statistics, hass, 1, STATISTIC_ID, convert_units=False, types={"sum"}
+        )
+    )
+    assert last[STATISTIC_ID][0]["sum"] == pytest.approx(19.96)
+
+
+async def test_statistics_import_failure_is_nonfatal(
+    hass: HomeAssistant,
+    mock_config_entry,
+    mock_sensor_name,
+    mock_watersmart_client,
+):
+    """A failure during statistics import does not prevent other sensors from loading."""
+    mock_recorder = MagicMock()
+    mock_recorder.async_add_executor_job = AsyncMock(
+        side_effect=RuntimeError("db error")
+    )
+
+    with patch(
+        "custom_components.watersmart.coordinator.get_instance",
+        return_value=mock_recorder,
+    ):
+        await _init(hass, mock_config_entry)
+
+        recent_hour = hass.states.get(
+            "sensor.watersmart_test_gallons_for_most_recent_hour"
+        )
+        assert recent_hour is not None
+        assert recent_hour.state not in {"unknown", "unavailable"}
+
+        total_sensor = hass.states.get(
+            "sensor.watersmart_test_total_hourly_usage"
+        )
+        assert total_sensor.state == "unknown"


### PR DESCRIPTION
## Summary

This PR adds two related features built on HA's long-term statistics system:

### Historical statistics import

On each coordinator update, all available hourly usage records are imported into the HA recorder as external statistics under the statistic ID `watersmart:<hostname>_hourly_usage`. The first refresh performs a full backfill of the API's available history; subsequent refreshes are incremental (only records newer than the last stored timestamp are added).

This makes the full historical data available in HA's **Statistics** card and **History** panel.

### "Total usage" sensor for the Energy Dashboard

Adds a new **Total usage** sensor (`state_class: TOTAL_INCREASING`, `device_class: water`) whose state is the cumulative running sum of all recorded gallons.

### manifest.json

Adds `after_dependencies: ["recorder"]` so HA waits for the recorder to be ready before setting up this integration.

## Test plan

- [x] Existing tests pass (updated snapshots to account for the new sensor entity being registered)
- [x] On first integration setup, verify HA recorder contains a statistic ID `watersmart:<hostname>_hourly_usage` with historical data going back to the earliest available API records
- [x] On subsequent coordinator refreshes, verify only new records are appended (incremental)
- [x] Verify **Energy Dashboard → Water consumption** shows "WaterSmart Total usage" as a selectable entity (not "entity without state")
- [x] Verify integration still works normally when recorder is unavailable (statistics import is non-fatal)