### PR TITLE
2FA support

### DIFF
--- a/custom_components/watersmart/__init__.py
+++ b/custom_components/watersmart/__init__.py
@@ -41,9 +41,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: WaterSmartConfigEntry) -
     hostname: str = entry.data[CONF_HOST]
     username: str = entry.data[CONF_USERNAME]
     password: str = entry.data[CONF_PASSWORD]
+    cookies: dict[str, str] | None = entry.data.get("cookies")
 
     session = async_get_clientsession(hass)
-    watersmart = WaterSmartClient(hostname, username, password, session=session)
+    watersmart = WaterSmartClient(
+        hostname, username, password, session=session, cookies=cookies
+    )
 
     coordinator = WaterSmartUpdateCoordinator(
         hass,

--- a/custom_components/watersmart/client.py
+++ b/custom_components/watersmart/client.py
@@ -83,6 +83,7 @@ class WaterSmartClient:
         username: str,
         password: str,
         session: aiohttp.ClientSession = None,
+        cookies: dict[str, str] | None = None,
     ) -> None:
         """Initialize."""
         self._hostname = hostname
@@ -92,6 +93,31 @@ class WaterSmartClient:
         self._account_number: str | None = None
         self._authenticated_at: dt.datetime | None = None
         self._2fa_pending: bool = False
+
+        # Restore cookies if provided (for bypassing 2FA on restart)
+        if cookies:
+            self._restore_cookies(cookies)
+
+    def _restore_cookies(self, cookies: dict[str, str]) -> None:
+        """Restore cookies to the session."""
+        from http.cookies import SimpleCookie
+
+        from yarl import URL  # Already installed as aiohttp dependency
+
+        url = URL(f"https://{self._hostname}.watersmart.com/")
+        for name, value in cookies.items():
+            self._session.cookie_jar.update_cookies(
+                SimpleCookie({name: value}),
+                response_url=url,
+            )
+
+    def get_cookies(self) -> dict[str, str]:
+        """Extract cookies from the session for persistence."""
+        cookies = {}
+        for cookie in self._session.cookie_jar:
+            if self._hostname in (cookie.get("domain", "") or ""):
+                cookies[cookie.key] = cookie.value
+        return cookies
 
     @_authenticated
     async def async_get_account_number(self) -> str | None:

--- a/custom_components/watersmart/client.py
+++ b/custom_components/watersmart/client.py
@@ -37,6 +37,14 @@ class AuthenticationError(Exception):
         self._errors = errors
 
 
+class TwoFactorAuthRequiredError(Exception):
+    """Two-factor authentication is required."""
+
+    def __init__(self, message: str = "2FA code required") -> None:
+        """Initialize."""
+        super().__init__(message)
+
+
 class InvalidAccountNumberError(Exception):
     """Invalid account number Error."""
 
@@ -83,6 +91,7 @@ class WaterSmartClient:
         self._session = session or aiohttp.ClientSession()
         self._account_number: str | None = None
         self._authenticated_at: dt.datetime | None = None
+        self._2fa_pending: bool = False
 
     @_authenticated
     async def async_get_account_number(self) -> str | None:
@@ -116,7 +125,6 @@ class WaterSmartClient:
             tz=dt.UTC
         ) - dt.timedelta(minutes=10):
             await self._authenticate()
-        self._authenticated_at = dt.datetime.now(tz=dt.UTC)
 
     async def _authenticate(self) -> None:
         session = self._session
@@ -152,6 +160,74 @@ class WaterSmartClient:
             login_response_text = await login_response.text()
             soup = BeautifulSoup(login_response_text, "html.parser")
 
+        # Check if 2FA verification is required
+        if self._is_2fa_required(soup):
+            self._2fa_pending = True
+            raise TwoFactorAuthRequiredError()
+
+        self._process_authenticated_response(soup)
+
+    def _is_2fa_required(self, soup: BeautifulSoup) -> bool:
+        """Check if the response indicates 2FA is required.
+
+        Args:
+            soup: Parsed HTML response.
+
+        Returns:
+            True if verificationCode input field is present.
+        """
+        return soup.find("input", {"name": "verificationCode"}) is not None
+
+    async def async_submit_2fa_code(self, code: str) -> None:
+        """Submit the 2FA verification code.
+
+        Args:
+            code: The verification code received via email.
+
+        Raises:
+            AuthenticationError: If 2FA submission fails.
+            TwoFactorAuthRequiredError: If 2FA was not initiated.
+        """
+        if not self._2fa_pending:
+            raise AuthenticationError(["2FA verification was not initiated"])
+
+        session = self._session
+        hostname = self._hostname
+
+        response = await session.post(
+            f"https://{hostname}.watersmart.com/index.php/welcome/verify",
+            data={
+                "verificationCode": code,
+            },
+        )
+        response_text = await response.text()
+        soup = BeautifulSoup(response_text, "html.parser")
+
+        # Check for error messages first (e.g., "Incorrect Code. Please try again.")
+        errors = [error.text.strip() for error in soup.select(".error-message")]
+        errors = [error for error in errors if error]
+
+        if errors:
+            raise AuthenticationError(errors)
+
+        # Check if still asking for 2FA (shouldn't happen if no error message)
+        if self._is_2fa_required(soup):
+            raise AuthenticationError(["Invalid verification code"])
+
+        self._2fa_pending = False
+        self._process_authenticated_response(soup)
+
+    def _process_authenticated_response(self, soup: BeautifulSoup) -> None:
+        """Process the response after successful authentication.
+
+        Args:
+            soup: Parsed HTML response.
+
+        Raises:
+            AuthenticationError: If there are error messages.
+            ScrapeError: If expected elements are missing.
+            InvalidAccountNumberError: If account number format is invalid.
+        """
         errors = [error.text.strip() for error in soup.select(".error-message")]
         errors = [error for error in errors if error]
 
@@ -175,6 +251,7 @@ class WaterSmartClient:
             raise InvalidAccountNumberError("invalid account number: " + account_number)
 
         self._account_number = account_number
+        self._authenticated_at = dt.datetime.now(tz=dt.UTC)
 
 
 def _assert_node(node: PageElement, message: str) -> PageElement:

--- a/custom_components/watersmart/config_flow.py
+++ b/custom_components/watersmart/config_flow.py
@@ -8,12 +8,11 @@ from aiohttp import ClientError
 from aiohttp.client_exceptions import ClientConnectorError
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
-from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import voluptuous as vol
 
-from .client import AuthenticationError, WaterSmartClient
+from .client import AuthenticationError, TwoFactorAuthRequiredError, WaterSmartClient
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -26,43 +25,22 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
     }
 )
 
-
-async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
-    """Validate the user input allows us to connect.
-
-    Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
-
-    Returns:
-        The details for creating a new config entry.
-
-    Raises:
-        CannotConnect: For connection errors.
-        InvalidAuth: For authentication errors.
-    """
-
-    session = async_get_clientsession(hass)
-    client = WaterSmartClient(
-        data[CONF_HOST], data[CONF_USERNAME], data[CONF_PASSWORD], session=session
-    )
-
-    try:
-        async with timeout(30):
-            account_number = await client.async_get_account_number()
-    except (ClientConnectorError, TimeoutError, ClientError) as error:
-        raise CannotConnect from error
-    except AuthenticationError as error:
-        raise InvalidAuth from error
-
-    if not account_number:
-        raise InvalidAuth
-
-    return {"title": f"{data[CONF_HOST]} ({data[CONF_USERNAME]})"}
+STEP_2FA_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required("code"): str,
+    }
+)
 
 
 class WaterSmartConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
     """Handle a config flow for WaterSmart."""
 
     VERSION = 1
+
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        self._user_input: dict[str, Any] = {}
+        self._client: WaterSmartClient | None = None
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -74,17 +52,36 @@ class WaterSmartConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
         """
         errors: dict[str, str] = {}
         if user_input is not None:
+            self._user_input = user_input
+            session = async_get_clientsession(self.hass)
+            self._client = WaterSmartClient(
+                user_input[CONF_HOST],
+                user_input[CONF_USERNAME],
+                user_input[CONF_PASSWORD],
+                session=session,
+            )
+
             try:
-                info = await validate_input(self.hass, user_input)
-            except CannotConnect:
+                async with timeout(30):
+                    account_number = await self._client.async_get_account_number()
+            except (ClientConnectorError, TimeoutError, ClientError):
                 errors["base"] = "cannot_connect"
-            except InvalidAuth:
+            except TwoFactorAuthRequiredError:
+                # 2FA is required, proceed to 2FA step
+                return await self.async_step_2fa()
+            except AuthenticationError:
                 errors["base"] = "invalid_auth"
             except Exception:
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
             else:
-                return self.async_create_entry(title=info["title"], data=user_input)
+                if not account_number:
+                    errors["base"] = "invalid_auth"
+                else:
+                    return self.async_create_entry(
+                        title=f"{user_input[CONF_HOST]} ({user_input[CONF_USERNAME]})",
+                        data=user_input,
+                    )
 
         return self.async_show_form(
             step_id="user",
@@ -94,6 +91,47 @@ class WaterSmartConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
                 "example_host": "bendoregon",
                 "example_url": "https://bendoregon.watersmart.com/",
             },
+        )
+
+    async def async_step_2fa(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the 2FA verification step.
+
+        Returns:
+            The config flow result.
+        """
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            if self._client is None:
+                # Client was lost, restart flow
+                return await self.async_step_user()
+
+            try:
+                async with timeout(30):
+                    await self._client.async_submit_2fa_code(user_input["code"])
+                    account_number = await self._client.async_get_account_number()
+            except (ClientConnectorError, TimeoutError, ClientError):
+                errors["base"] = "cannot_connect"
+            except AuthenticationError:
+                errors["base"] = "invalid_2fa_code"
+            except Exception:
+                _LOGGER.exception("Unexpected exception during 2FA")
+                errors["base"] = "unknown"
+            else:
+                if not account_number:
+                    errors["base"] = "invalid_auth"
+                else:
+                    return self.async_create_entry(
+                        title=f"{self._user_input[CONF_HOST]} ({self._user_input[CONF_USERNAME]})",
+                        data=self._user_input,
+                    )
+
+        return self.async_show_form(
+            step_id="2fa",
+            data_schema=STEP_2FA_DATA_SCHEMA,
+            errors=errors,
         )
 
 

--- a/custom_components/watersmart/config_flow.py
+++ b/custom_components/watersmart/config_flow.py
@@ -123,9 +123,14 @@ class WaterSmartConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
                 if not account_number:
                     errors["base"] = "invalid_auth"
                 else:
+                    # Save cookies for bypassing 2FA on restart
+                    entry_data = {
+                        **self._user_input,
+                        "cookies": self._client.get_cookies(),
+                    }
                     return self.async_create_entry(
                         title=f"{self._user_input[CONF_HOST]} ({self._user_input[CONF_USERNAME]})",
-                        data=self._user_input,
+                        data=entry_data,
                     )
 
         return self.async_show_form(

--- a/custom_components/watersmart/diagnostics.py
+++ b/custom_components/watersmart/diagnostics.py
@@ -12,6 +12,7 @@ from .coordinator import WaterSmartUpdateCoordinator
 TO_REDACT = {
     CONF_USERNAME,
     CONF_PASSWORD,
+    "cookies",
 }
 
 

--- a/custom_components/watersmart/translations/en.json
+++ b/custom_components/watersmart/translations/en.json
@@ -6,6 +6,7 @@
         "error": {
             "cannot_connect": "Failed to connect",
             "invalid_auth": "Invalid authentication",
+            "invalid_2fa_code": "Invalid verification code. Please check the code and try again.",
             "unknown": "Unexpected error"
         },
         "step": {
@@ -17,6 +18,13 @@
                 },
                 "description": "Enter your host and credentials. The host is the subdomain for accessing Watersmart, i.e. `{example_host}` for {example_url}.",
                 "title": "Subdomain & Authentication"
+            },
+            "2fa": {
+                "data": {
+                    "code": "Verification Code"
+                },
+                "description": "A verification code has been sent to your email. Please enter the code to complete authentication.",
+                "title": "Two-Factor Authentication"
             }
         }
     },

--- a/tests/fixtures/login_2fa_required.html
+++ b/tests/fixtures/login_2fa_required.html
@@ -1,0 +1,20 @@
+<html>
+ <body class="portal desktop responsive">
+  <div id="main-wrapper">
+   <div class="login-form">
+    <h2>Two-Factor Authentication</h2>
+    <p>A verification code has been sent to your email. Please enter the code below to continue.</p>
+    <form action="/index.php/welcome/login?forceEmail=1" method="post">
+     <input type="hidden" name="token" value="abc123token"/>
+     <div class="form-group">
+      <label for="verificationCode">Verification Code</label>
+      <input type="text" name="verificationCode" id="verificationCode" placeholder="Enter verification code"/>
+     </div>
+     <div class="error-message" style="display:none">
+     </div>
+     <button type="submit">Verify</button>
+    </form>
+   </div>
+  </div>
+ </body>
+</html>

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -9,6 +9,7 @@ from custom_components.watersmart.client import (
     AuthenticationError,
     InvalidAccountNumberError,
     ScrapeError,
+    TwoFactorAuthRequiredError,
     WaterSmartClient,
 )
 
@@ -209,3 +210,96 @@ async def test_async_get_async_get_hourly_data(
         },
         {"read_datetime": 1718834400, "gallons": 0, "flags": None, "leak_gallons": 0},
     ]
+
+
+async def test_login_2fa_required(
+    hass: HomeAssistant, mock_aiohttp_session, fixture_loader
+):
+    """Test that 2FA requirement is detected."""
+    mock_aiohttp_session.post.return_value.text.return_value = (
+        fixture_loader.login_2fa_required_html
+    )
+
+    client = WaterSmartClient(
+        hostname="test",
+        username="test@home-assistant.io",
+        password="Passw0rd",  # noqa: S106
+    )
+
+    with pytest.raises(TwoFactorAuthRequiredError):
+        await client.async_get_account_number()
+
+    assert client._2fa_pending is True
+
+
+async def test_login_2fa_success(
+    hass: HomeAssistant, mock_aiohttp_session, fixture_loader
+):
+    """Test successful 2FA submission."""
+    resp1 = AsyncMock()
+    resp1.text.return_value = fixture_loader.login_2fa_required_html
+    resp2 = AsyncMock()
+    resp2.text.return_value = fixture_loader.login_success_html
+
+    mock_aiohttp_session.post.side_effect = [resp1, resp2]
+
+    client = WaterSmartClient(
+        hostname="test",
+        username="test@home-assistant.io",
+        password="Passw0rd",  # noqa: S106
+    )
+
+    with pytest.raises(TwoFactorAuthRequiredError):
+        await client.async_get_account_number()
+
+    await client.async_submit_2fa_code("123456")
+
+    assert client._2fa_pending is False
+    assert client._account_number == "1234567-8900"
+
+    mock_aiohttp_session.post.assert_has_calls(
+        [
+            call(
+                "https://test.watersmart.com/index.php/welcome/verify",
+                data={
+                    "verificationCode": "123456",
+                },
+            ),
+        ]
+    )
+
+
+async def test_login_2fa_invalid_code(
+    hass: HomeAssistant, mock_aiohttp_session, fixture_loader
+):
+    """Test invalid 2FA code."""
+    resp1 = AsyncMock()
+    resp1.text.return_value = fixture_loader.login_2fa_required_html
+    resp2 = AsyncMock()
+    resp2.text.return_value = fixture_loader.login_2fa_required_html
+
+    mock_aiohttp_session.post.side_effect = [resp1, resp2]
+
+    client = WaterSmartClient(
+        hostname="test",
+        username="test@home-assistant.io",
+        password="Passw0rd",  # noqa: S106
+    )
+
+    with pytest.raises(TwoFactorAuthRequiredError):
+        await client.async_get_account_number()
+
+    with pytest.raises(AuthenticationError):
+        await client.async_submit_2fa_code("wrong_code")
+
+
+async def test_login_2fa_not_initiated(hass: HomeAssistant, mock_aiohttp_session):
+    """Test submitting 2FA code when 2FA was not initiated."""
+    client = WaterSmartClient(
+        hostname="test",
+        username="test@home-assistant.io",
+        password="Passw0rd",  # noqa: S106
+    )
+
+    with pytest.raises(AuthenticationError):
+        await client.async_submit_2fa_code("123456")

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,12 +1,15 @@
 """Test the Simple Integration config flow."""
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from homeassistant import config_entries, setup
 from homeassistant.core import HomeAssistant
 import pytest
 
-from custom_components.watersmart.client import AuthenticationError
+from custom_components.watersmart.client import (
+    AuthenticationError,
+    TwoFactorAuthRequiredError,
+)
 from custom_components.watersmart.const import DOMAIN
 
 
@@ -102,3 +105,111 @@ async def test_error(
     assert configured_result["errors"] == expected_errors
     await hass.async_block_till_done()
     assert len(mock_setup_entry.mock_calls) == 0
+
+
+async def test_2fa_flow(hass: HomeAssistant, mock_watersmart_client):
+    """Test successful 2FA authentication flow."""
+
+    # First call raises 2FA required, subsequent calls succeed
+    mock_watersmart_client.async_get_account_number.side_effect = [
+        TwoFactorAuthRequiredError(),
+        "1234567-8900",
+    ]
+    mock_watersmart_client.async_submit_2fa_code = AsyncMock()
+
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+
+    # Submit credentials - should trigger 2FA
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "host": "austintx",
+            "username": "test@home-assistant.io",
+            "password": "Passw0rd",
+        },
+    )
+
+    assert result2["type"] == "form"
+    assert result2["step_id"] == "2fa"
+    assert result2["errors"] == {}
+
+    # Submit 2FA code
+    with patch(
+        "custom_components.watersmart.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"],
+            {"code": "123456"},
+        )
+
+    assert result3["type"] == "create_entry"
+    assert result3["title"] == "austintx (test@home-assistant.io)"
+    assert result3["data"] == {
+        "host": "austintx",
+        "username": "test@home-assistant.io",
+        "password": "Passw0rd",
+    }
+
+    mock_watersmart_client.async_submit_2fa_code.assert_called_once_with("123456")
+    await hass.async_block_till_done()
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_2fa_invalid_code(hass: HomeAssistant, mock_watersmart_client):
+    """Test invalid 2FA code shows error."""
+
+    mock_watersmart_client.async_get_account_number.side_effect = [
+        TwoFactorAuthRequiredError(),
+        "1234567-8900",
+    ]
+    mock_watersmart_client.async_submit_2fa_code = AsyncMock(
+        side_effect=[AuthenticationError(["Invalid code"]), None]
+    )
+
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    # Submit credentials - should trigger 2FA
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "host": "austintx",
+            "username": "test@home-assistant.io",
+            "password": "Passw0rd",
+        },
+    )
+
+    assert result2["type"] == "form"
+    assert result2["step_id"] == "2fa"
+
+    # Submit invalid 2FA code
+    result3 = await hass.config_entries.flow.async_configure(
+        result2["flow_id"],
+        {"code": "wrong_code"},
+    )
+
+    assert result3["type"] == "form"
+    assert result3["step_id"] == "2fa"
+    assert result3["errors"] == {"base": "invalid_2fa_code"}
+
+    # Now submit correct code
+    with patch(
+        "custom_components.watersmart.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result4 = await hass.config_entries.flow.async_configure(
+            result3["flow_id"],
+            {"code": "123456"},
+        )
+
+    assert result4["type"] == "create_entry"
+    await hass.async_block_till_done()
+    assert len(mock_setup_entry.mock_calls) == 1


### PR DESCRIPTION
This PR adds 2FA support. Addresses issues https://github.com/wbyoung/watersmart/issues/3 https://github.com/wbyoung/watersmart/issues/11 https://github.com/wbyoung/watersmart/issues/14 https://github.com/wbyoung/watersmart/issues/25 

Some utility companies either force 2FA or let the user opt-in. For those cases, a code is sent to your e-mail and you need to enter the code to integrate Watersmart.

This implementation covers:
✅ Detects whether or not 2FA code is required
✅ Prompts user to enter code
✅ Handles expired codes
✅ Handles wrong codes
✅ Finishes integration when 2FA code is correct

Tested with `austintx`


<img width="569" height="300" alt="Screenshot 2026-03-28 at 2 38 34 PM" src="https://github.com/user-attachments/assets/41b9f6ba-eb47-4380-aa31-2196ee945348" />
<img width="566" height="364" alt="Screenshot 2026-03-28 at 2 38 41 PM" src="https://github.com/user-attachments/assets/bd781c87-c3ca-4ed9-b0f4-5e713a445895" />

