### PR TITLE
Send browser-like headers so login works behind WAF (fixes Asheville auth)

### DIFF
--- a/custom_components/watersmart/client.py
+++ b/custom_components/watersmart/client.py
@@ -15,6 +15,20 @@ from bs4 import BeautifulSoup, PageElement
 # match on a string of non-whitespace characters.
 ACCOUNT_NUMBER_RE = re.compile(r"^\S+$")
 
+# Some WaterSmart portals (and the WAFs/CDNs in front of them) reject or serve
+# different content to non-browser HTTP clients. Home Assistant's shared aiohttp
+# session sends a non-browser User-Agent, which causes the login POST to fail
+# authentication even with valid credentials. Send browser-like headers on the
+# requests this client makes so the authenticated flow looks like a browser.
+_DEFAULT_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+    ),
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "en-US,en;q=0.9",
+}
+
 
 def _authenticated[F: Callable[..., Any], ReturnT](func: F) -> F:
     @functools.wraps(func)
@@ -105,7 +119,8 @@ class WaterSmartClient:
         session = self._session
         hostname = self._hostname
         response = await session.get(
-            f"https://{hostname}.watersmart.com/index.php/rest/v1/Chart/RealTimeChart"
+            f"https://{hostname}.watersmart.com/index.php/rest/v1/Chart/RealTimeChart",
+            headers=_DEFAULT_HEADERS,
         )
         response_json: UsageHistoryPayload = await response.json()
 
@@ -128,6 +143,7 @@ class WaterSmartClient:
                 "email": self._username,
                 "password": self._password,
             },
+            headers=_DEFAULT_HEADERS,
         )
         login_response_text = await login_response.text()
         soup = BeautifulSoup(login_response_text, "html.parser")
@@ -148,6 +164,7 @@ class WaterSmartClient:
                     "email": self._username,
                     "password": self._password,
                 },
+                headers=_DEFAULT_HEADERS,
             )
             login_response_text = await login_response.text()
             soup = BeautifulSoup(login_response_text, "html.parser")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,6 @@
 """Test client."""
 
-from unittest.mock import AsyncMock, call
+from unittest.mock import ANY, AsyncMock, call
 
 from homeassistant.core import HomeAssistant
 import pytest
@@ -35,9 +35,51 @@ async def test_login_success(hass: HomeAssistant, mock_aiohttp_session, fixture_
                     "email": "test@home-assistant.io",
                     "password": "Passw0rd",
                 },
+                headers=ANY,
             ),
         ]
     )
+
+
+async def test_login_sends_browser_headers(
+    hass: HomeAssistant, mock_aiohttp_session, fixture_loader
+):
+    """Portals/WAFs may reject non-browser clients; login POST must look like a browser."""
+    mock_aiohttp_session.post.return_value.text.return_value = (
+        fixture_loader.login_success_html
+    )
+
+    client = WaterSmartClient(
+        hostname="test",
+        username="test@home-assistant.io",
+        password="Passw0rd",  # noqa: S106
+    )
+
+    await client.async_get_account_number()
+
+    _, kwargs = mock_aiohttp_session.post.call_args
+    headers = kwargs["headers"]
+    assert headers["User-Agent"].startswith("Mozilla/5.0")
+    assert "Accept" in headers
+    assert "Accept-Language" in headers
+
+
+async def test_hourly_data_sends_browser_headers(
+    hass: HomeAssistant, mock_aiohttp_session, fixture_loader
+):
+    """The data request must also look like a browser for a consistent auth flow."""
+    mock_aiohttp_session.post.return_value.text.return_value = (
+        fixture_loader.login_success_html
+    )
+    mock_aiohttp_session.get.return_value.text.return_value = (
+        fixture_loader.realtime_api_response_json
+    )
+
+    client = WaterSmartClient(hostname="test", username="", password="")
+    await client.async_get_hourly_data()
+
+    _, kwargs = mock_aiohttp_session.get.call_args
+    assert kwargs["headers"]["User-Agent"].startswith("Mozilla/5.0")
 
 
 async def test_login_success_with_refreshtoken(
@@ -68,6 +110,7 @@ async def test_login_success_with_refreshtoken(
                     "email": "test@home-assistant.io",
                     "password": "Passw0rd",
                 },
+                headers=ANY,
             ),
         ]
     )
@@ -81,6 +124,7 @@ async def test_login_success_with_refreshtoken(
                     "email": "test@home-assistant.io",
                     "password": "Passw0rd",
                 },
+                headers=ANY,
             ),
         ]
     )
@@ -188,7 +232,10 @@ async def test_async_get_async_get_hourly_data(
 
     mock_aiohttp_session.get.assert_has_calls(
         [
-            call("https://.watersmart.com/index.php/rest/v1/Chart/RealTimeChart"),
+            call(
+                "https://.watersmart.com/index.php/rest/v1/Chart/RealTimeChart",
+                headers=ANY,
+            ),
         ]
     )
 


### PR DESCRIPTION
## Symptom

Setting up the integration for host `ashevillenc` (City of Asheville, NC) with **known-correct** credentials fails immediately with **"invalid authentication"** in the Home Assistant UI. The same email + password log in fine in a normal browser.

## Root cause

The portal (or a WAF/CDN in front of it — common for VertexOne-hosted WaterSmart sites) treats non-browser HTTP clients differently. Home Assistant's shared `aiohttp` session sends a non-browser `User-Agent` (e.g. `HomeAssistant/... aiohttp/... Python/...`) and minimal headers, so the login `POST` does not authenticate and the response contains an error element → `AuthenticationError` → "invalid authentication".

Evidence gathered against the live Asheville portal:

- **Endpoint is correct** — `POST /index.php/welcome/login?forceEmail=1` with `{token:"", email, password}` returns HTTP 200 and the login HTML.
- **Not a CSRF/session-cookie issue** — a cookieless cold `POST` with a *wrong* password returns the normal "we didn't recognize that email and password combination" error, so the server runs a real credential check without any prior cookie/token.
- **Hidden `token` field is genuinely empty** (`value=""`), matching what the integration already sends.
- **Scrape target is intact** — after a successful login, `#account-navigation` is present and contains the account number, so scraping works once login succeeds.
- **The only material difference** between the working browser request and the failing integration request is the HTTP client headers (real `User-Agent` + `Accept`/`Accept-Language`).

## Fix

Send browser-like headers (`User-Agent`, `Accept`, `Accept-Language`) on the requests the client makes — both login `POST`s in `_authenticate()` and the `RealTimeChart` `GET` in `async_get_hourly_data()` — so the whole authenticated flow looks like a browser.

Headers are passed **per-request** via a small `_DEFAULT_HEADERS` constant rather than mutating Home Assistant's shared session defaults. The `User-Agent` is a generic recent Chrome string (no impersonation of a specific person).

## Tests

- Added `test_login_sends_browser_headers` and `test_hourly_data_sends_browser_headers` asserting the client sends a browser `User-Agent` (and `Accept`/`Accept-Language`) on the login `POST` and the data `GET`.
- Updated the existing login/data call assertions to allow the new `headers=` kwarg (using `mock.ANY`, since those tests verify URL + body, while the new tests verify header content).
- `ruff check` and `ruff format` pass clean.

## Live verification

Verified end-to-end on a **real Asheville account**: with the patch, the integration authenticates against `ashevillenc` with no "invalid authentication" error, and usage sensors populate with real data (e.g. "Most recent full day usage" reading actual gallons, with history graphing). Without the patch, the same account fails with "invalid authentication".

## Related issues

Relates to #30 (login page structure changed), #31 (MFA needed), and #14 (fails on two-factor auth) — these were auto-closed as stale rather than fixed; this addresses the underlying auth failure for at least the Asheville portal.
