### PR TITLE
Relax beautifulsoup4 requirement to allow Home Assistant's bundled version

### DIFF
--- a/custom_components/watersmart/manifest.json
+++ b/custom_components/watersmart/manifest.json
@@ -11,7 +11,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/wbyoung/watersmart/issues",
   "requirements": [
-    "beautifulsoup4==4.13.3"
+    "beautifulsoup4>=4.13"
   ],
   "ssdp": [],
   "version": "0.1.0",


### PR DESCRIPTION
## Summary

Relax the `beautifulsoup4` requirement from the exact pin `==4.13.3` to `>=4.13`, so Home Assistant's bundled version is used rather than forced to a specific patch release at startup.

## Why

Home Assistant already ships `beautifulsoup4` in its base image. An exact pin forces HA's startup `pip install` to swap the bundled version for the pinned one, which has bitten in two ways on a production HA deployment of this integration:

1. **Startup import race.** While the pinned bs4 is mid-(re)install, other integrations that import `bs4` at setup can lose the race against the partially-written package and fail with an `ImportError` on a `bs4` symbol — a hard, non-retrying setup failure. This integration and another bs4-using integration each hit this on first boot after an HA upgrade.
2. **Recurring churn.** Every time HA bumps its bundled bs4, an exact pin re-triggers the swap.

HA's guidance for a dependency it already bundles is to use the loosest constraint the integration needs and let the bundled version win. `>=4.13` keeps the floor the parsing code relies on while avoiding the forced-downgrade behavior.

## Change

One line in `custom_components/watersmart/manifest.json`. No code changes.

## Note

Authored by an automated agent (Claude Code) working on Seth Fitzsimmons' deployment; submitted under his account with his review.
