### PR TITLE
Add Energy dashboard support

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,38 @@ Gallons of water used on the most recent hour of data available.
 * `related`: List of related objects with `start` and `gallons` starting from the most recent
   hour.
 
+## Energy dashboard
+
+The integration imports the hourly water-usage series into Home Assistant's
+long-term statistics, making it available to the [Energy dashboard's water
+consumption section][energy-water].
+
+Home Assistant stores a consumption series as a running total: every hourly row
+holds both that hour's usage and the cumulative total of all the hours before
+it. WaterSmart reports each hour on its own, so the integration accumulates the
+hourly values into that running total before recording them.
+
+On first run it imports the entire history WaterSmart exposes for the account,
+accumulating from zero. Later refreshes do not recompute the whole total.
+Instead they find the most recent hour already recorded that is old enough to
+have settled — roughly two days back, since WaterSmart keeps revising more
+recent hours — and resume accumulating from that hour's running total,
+re-importing every hour after it. Revisions WaterSmart has made inside that
+window are picked up; older rows are left untouched.
+
+The statistic appears in the Energy dashboard's water-source picker labeled
+`Water consumption (<host>)`. Its `statistic_id` is derived from the config
+entry's internal id (`watersmart:<entry_id>`) rather than from the host or
+username, so re-authenticating or editing either one keeps writing to the same
+series instead of stranding it and starting a new one.
+
+### Known limitations
+
+- Historical corrections that WaterSmart emits more than roughly two days after
+  the fact are not picked up automatically. If this matters for a particular
+  account, removing and re-adding the config entry triggers a fresh full
+  backfill.
+
 ## Services
 
 ### `watersmart.get_hourly_history`
@@ -97,6 +129,7 @@ Icon designed by [bsd studio][bsd-attribution].
 
 [bsd-attribution]: https://thenounproject.com/creator/nesterenko.ruslan
 [config-flow-start]: https://my.home-assistant.io/redirect/config_flow_start/?domain=watersmart
+[energy-water]: https://www.home-assistant.io/docs/energy/water/
 [hacs]: https://hacs.xyz/
 [hacs-repo]: https://github.com/hacs/integration
 [hacs-badge]: https://my.home-assistant.io/badges/hacs_repository.svg

--- a/custom_components/watersmart/__init__.py
+++ b/custom_components/watersmart/__init__.py
@@ -10,6 +10,7 @@ from .client import WaterSmartClient
 from .const import DOMAIN
 from .coordinator import WaterSmartUpdateCoordinator
 from .services import async_setup_services
+from .statistics import clear as clear_statistics
 from .types import WaterSmartConfigEntry, WaterSmartData
 
 PLATFORMS: list[Platform] = [Platform.SENSOR]
@@ -50,6 +51,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: WaterSmartConfigEntry) -
         watersmart,
         hostname,
         username,
+        entry_id=entry.entry_id,
     )
 
     await coordinator.async_config_entry_first_refresh()
@@ -72,3 +74,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: WaterSmartConfigEntry) 
         If the unload was successful.
     """
     return bool(await hass.config_entries.async_unload_platforms(entry, PLATFORMS))
+
+
+async def async_remove_entry(  # noqa: RUF029
+    hass: HomeAssistant, entry: WaterSmartConfigEntry
+) -> None:
+    """Clear the integration's external statistics series on entry removal."""
+    clear_statistics(hass, entry)

--- a/custom_components/watersmart/coordinator.py
+++ b/custom_components/watersmart/coordinator.py
@@ -8,11 +8,19 @@ import logging
 from typing import Any, Protocol, TypedDict, cast
 
 from aiohttp.client_exceptions import ClientConnectorError
+from homeassistant.components.recorder import get_instance
+from homeassistant.components.recorder.models import StatisticData
+from homeassistant.components.recorder.statistics import (
+    async_add_external_statistics,
+    get_last_statistics,
+    statistics_during_period,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util.dt import as_local, get_default_time_zone, start_of_local_day
 
+from . import statistics as stats
 from .client import AuthenticationError, UsageRecord, WaterSmartClient
 from .const import DEFAULT_SCAN_INTERVAL, DOMAIN, MANUFACTURER, SensorKey
 from .types import SensorData
@@ -20,6 +28,10 @@ from .types import SensorData
 EXCEPTIONS = (AuthenticationError, ClientConnectorError)
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class _RecorderQueryFailed(Exception):
+    """A recorder query raised; the statistics import is abandoned this cycle."""
 
 
 class CoordinatorData(TypedDict, total=False):
@@ -47,6 +59,8 @@ class WaterSmartUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
         watersmart: WaterSmartClient,
         hostname: str,
         username: str,
+        *,
+        entry_id: str,
     ) -> None:
         """Initialize."""
 
@@ -60,6 +74,7 @@ class WaterSmartUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
         self.watersmart = watersmart
         self.hostname = hostname
         self.username = username
+        self.entry_id = entry_id
         self.device_info = _get_device_info(hostname, username)
         self.data: CoordinatorData = {}
         self.data_converters = (
@@ -89,9 +104,120 @@ class WaterSmartUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
                 result
             )
 
+        await self._insert_statistics(result["hourly"])
+
         _LOGGER.debug("Async update complete")
 
         return result
+
+    async def _insert_statistics(self, hourly: list[UsageRecord]) -> None:
+        """Import the hourly series into HA's long-term statistics.
+
+        Cold start: fold every record against a zero anchor and upsert.
+
+        Warm refresh: re-fold the trailing window onto the most recent anchor
+        row so late upstream corrections are absorbed (see :mod:`.statistics`).
+
+        Errors from the recorder are logged and swallowed: a recorder failure
+        must not mask the sensor data the refresh succeeded in producing.
+        """
+        try:
+            anchor = await self._resolve_anchor()
+            rows = stats.fold_cumulative(stats.bucket_records(hourly), anchor)
+            if not rows:
+                _LOGGER.debug("No new statistics buckets to import")
+                return
+            self._write_statistics(rows)
+        except _RecorderQueryFailed:
+            return
+
+        _LOGGER.debug("Imported %d statistics rows", len(rows))
+
+    async def _resolve_anchor(self) -> stats.Anchor:
+        """Resolve the cumulative anchor the trailing window folds onto.
+
+        Returns:
+            A cold-start anchor when no prior statistics exist, otherwise the
+            warm-refresh anchor selected from the recorder.
+        """
+        statistic_id = stats.statistic_id_for(self.entry_id)
+
+        # Both queries read back cumulative sums that the next fold accumulates
+        # onto, so they must arrive in the unit the series is stored in.
+        # `convert_units` and `units` would render them in the display unit
+        # instead, silently mixing units into the running total.
+        last = await self._recorder_query(
+            "read last statistics",
+            functools.partial(
+                get_last_statistics,
+                self.hass,
+                1,
+                statistic_id,
+                convert_units=False,
+                types={"sum"},
+            ),
+        )
+        last_rows = last.get(statistic_id, [])
+        if not last_rows:
+            return stats.COLD_START
+
+        last_row = last_rows[0]
+        window_start, window_end = stats.anchor_window(last_row)
+        window = await self._recorder_query(
+            "look up anchor statistics",
+            functools.partial(
+                statistics_during_period,
+                self.hass,
+                window_start,
+                window_end,
+                statistic_ids={statistic_id},
+                period="hour",
+                units=None,
+                types={"sum"},
+            ),
+        )
+        window_rows = window.get(statistic_id, [])
+        if not window_rows:
+            _LOGGER.warning(
+                "No anchor row in the trailing window for %s despite an "
+                "existing series; re-folding the whole history this refresh",
+                statistic_id,
+            )
+        return stats.select_anchor(window_rows)
+
+    async def _recorder_query(
+        self,
+        description: str,
+        query: Callable[[], dict[str, Any]],
+    ) -> dict[str, Any]:
+        """Run a recorder query off the event loop, swallowing failures.
+
+        Returns:
+            The query result keyed by statistic id.
+
+        Raises:
+            _RecorderQueryFailed: If ``query`` raised.
+        """
+        try:
+            result = await get_instance(self.hass).async_add_executor_job(query)
+        except Exception as error:
+            _LOGGER.warning("Failed to %s", description, exc_info=True)
+            raise _RecorderQueryFailed from error
+        # async_add_executor_job's stub erases func's return type to Any.
+        return cast("dict[str, Any]", result)
+
+    def _write_statistics(self, rows: list[StatisticData]) -> None:
+        """Upsert statistic rows.
+
+        Raises:
+            _RecorderQueryFailed: If the recorder write failed.
+        """
+        metadata = stats.metadata_for(self.entry_id, self.hostname)
+        try:
+            async_add_external_statistics(self.hass, metadata, rows)
+        except Exception as error:
+            _LOGGER.warning("Failed to write statistics", exc_info=True)
+            raise _RecorderQueryFailed from error
 
 
 def _get_device_info(hostname: str, username: str) -> DeviceInfo:

--- a/custom_components/watersmart/manifest.json
+++ b/custom_components/watersmart/manifest.json
@@ -5,7 +5,9 @@
     "@wbyoung"
   ],
   "config_flow": true,
-  "dependencies": [],
+  "dependencies": [
+    "recorder"
+  ],
   "documentation": "https://github.com/wbyoung/watersmart",
   "homekit": {},
   "iot_class": "cloud_polling",

--- a/custom_components/watersmart/statistics.py
+++ b/custom_components/watersmart/statistics.py
@@ -1,0 +1,210 @@
+"""WaterSmart long-term-statistics import.
+
+Home Assistant records a consumption series as a running total: each hourly row
+carries that hour's own usage in ``state`` and the cumulative total of every
+hour up to and including it in ``sum``. WaterSmart reports each hour on its own,
+so the hourly values have to be accumulated before the recorder will take them.
+
+Two terms recur below. *Folding* is that accumulation -- turning per-hour
+gallons into rows whose ``sum`` is the running total. An *anchor* is the row a
+fold resumes from, identified by its hour and the running total reached there.
+
+A cold start folds the whole history from zero. A warm refresh anchors on an
+already-recorded hour far enough back to be settled and folds only the hours
+after it, so the recent hours WaterSmart still restates are recomputed while
+older rows are left alone.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+import datetime as dt
+from operator import itemgetter
+from typing import Any, cast
+
+from homeassistant.components.recorder import get_instance
+from homeassistant.components.recorder.models import (
+    StatisticData,
+    StatisticMeanType,
+    StatisticMetaData,
+)
+from homeassistant.const import UnitOfVolume
+from homeassistant.core import HomeAssistant
+from homeassistant.util.unit_conversion import VolumeConverter
+
+from .client import UsageRecord
+from .const import DOMAIN
+from .types import WaterSmartConfigEntry
+
+# A warm refresh re-folds the trailing window of buckets so late upstream
+# corrections are absorbed without rewriting the whole series.
+REFOLD_WINDOW = dt.timedelta(hours=48)
+# The anchor lookup spans a 25h window so a bucket landing exactly on the
+# cutoff is still found.
+ANCHOR_LOOKBACK = dt.timedelta(hours=24)
+# ``unit_class`` names the converter the recorder uses to render the series in
+# the user's preferred volume unit. The recorder gained the field in HA
+# 2025.11.0 and builds its metadata row with ``StatisticsMeta(**metadata)``, so
+# an older recorder raises TypeError on the key instead of ignoring it. Probe
+# for the field rather than pinning a minimum HA version; delete the probe once
+# the supported floor reaches 2025.11.0.
+_SUPPORTS_UNIT_CLASS = "unit_class" in StatisticMetaData.__annotations__
+
+
+def _utc_from_epoch(timestamp: float) -> dt.datetime:
+    """Interpret an epoch timestamp as a UTC datetime.
+
+    Both source representations the import consumes -- the client's
+    ``read_datetime`` and the recorder's ``StatisticsRow["start"]`` -- carry
+    times as epoch seconds; the fold works in UTC datetimes throughout.
+
+    Returns:
+        The timestamp as a timezone-aware UTC datetime.
+    """
+    return dt.datetime.fromtimestamp(timestamp, tz=dt.UTC)
+
+
+def statistic_id_for(entry_id: str) -> str:
+    """Return the external statistic id for this config entry.
+
+    HA config-entry ids are uppercase ULIDs, but HA requires statistic ids to
+    be slugs (lowercase). ULIDs are case-insensitive Crockford base32, so
+    lowercasing is lossless and keeps the statistic id 1:1 with the entry.
+    """
+    return f"{DOMAIN}:{entry_id.lower()}"
+
+
+def metadata_for(entry_id: str, hostname: str) -> StatisticMetaData:
+    """Build the external-statistics metadata for this config entry.
+
+    Water usage is an accumulated-quantity statistic: each hour's value is the
+    total consumed during that hour. ``has_sum=True``; ``mean_type`` is
+    ``StatisticMeanType.NONE`` because there are no underlying instantaneous
+    observations to average. ``unit_class`` is set only on recorders that
+    accept it (see :data:`_SUPPORTS_UNIT_CLASS`).
+
+    Returns:
+        Metadata describing the external-statistics series for the entry.
+    """
+    # Assembled as a plain mapping because the accepted keys vary by HA version.
+    metadata: dict[str, Any] = {
+        "mean_type": StatisticMeanType.NONE,
+        "has_sum": True,
+        "name": f"Water consumption ({hostname})",
+        "source": DOMAIN,
+        "statistic_id": statistic_id_for(entry_id),
+        "unit_of_measurement": UnitOfVolume.GALLONS,
+    }
+    if _SUPPORTS_UNIT_CLASS:
+        metadata["unit_class"] = VolumeConverter.UNIT_CLASS
+    return cast("StatisticMetaData", metadata)
+
+
+def bucket_records(
+    records: Iterable[UsageRecord],
+) -> list[tuple[dt.datetime, float]]:
+    """Group records by UTC hour.
+
+    Drops records with ``gallons is None``; sums multiple records that fall
+    within the same UTC hour (sub-hour timestamp jitter in the source data can
+    place two readings in one hour); returns the result sorted chronologically.
+
+    Returns:
+        ``(hour_start_utc, gallons)`` pairs sorted chronologically.
+    """
+    buckets: dict[dt.datetime, float] = {}
+    for record in records:
+        gallons = record["gallons"]
+        if gallons is None:
+            continue
+        start = _utc_from_epoch(record["read_datetime"]).replace(
+            minute=0, second=0, microsecond=0
+        )
+        buckets[start] = buckets.get(start, 0.0) + gallons
+    return sorted(buckets.items())
+
+
+def fold_cumulative(
+    buckets: Iterable[tuple[dt.datetime, float]],
+    anchor: Anchor,
+) -> list[StatisticData]:
+    """Fold per-hour gallons after ``anchor`` into cumulative-sum statistic rows.
+
+    Buckets at or before ``anchor.start`` are dropped; the rest accumulate onto
+    ``anchor.sum`` to form each row's ``sum``. Each row's ``state`` is that
+    hour's own gallons, not the running total: HA's external-statistics
+    convention pairs a per-period ``state`` with the cumulative ``sum`` (the
+    Energy dashboard reads ``sum``, and the statistics UI derives each period's
+    change from consecutive sums while ``state`` records the period value).
+
+    Returns:
+        Cumulative-sum statistic rows in chronological order.
+    """
+    rows: list[StatisticData] = []
+    running = anchor.sum
+    for start, gallons in buckets:
+        if anchor.start is not None and start <= anchor.start:
+            continue
+        running += gallons
+        rows.append(StatisticData(start=start, state=gallons, sum=running))
+    return rows
+
+
+@dataclass(frozen=True)
+class Anchor:
+    """The cumulative state a fold continues from.
+
+    ``start`` is ``None`` on a cold start, meaning every bucket is folded;
+    otherwise only buckets strictly after ``start`` are folded onto ``sum``.
+    """
+
+    start: dt.datetime | None
+    sum: float
+
+
+# A cold start (no prior statistics row) folds the whole series from zero.
+COLD_START = Anchor(start=None, sum=0.0)
+
+
+def anchor_window(last_row: Mapping[str, Any]) -> tuple[dt.datetime, dt.datetime]:
+    """Return the time span to search for a warm-refresh anchor row.
+
+    The window ends one refold-window before ``last_row`` and reaches back a
+    further lookback span so a bucket on the cutoff boundary is still found.
+
+    Returns:
+        ``(window_start, window_end)`` for ``statistics_during_period``.
+    """
+    cutoff = _utc_from_epoch(last_row["start"]) - REFOLD_WINDOW
+    return cutoff - ANCHOR_LOOKBACK, cutoff + dt.timedelta(hours=1)
+
+
+def select_anchor(window_rows: Sequence[Mapping[str, Any]]) -> Anchor:
+    """Choose the anchor a warm refresh folds the trailing window onto.
+
+    Anchors on the most recent statistics row inside :func:`anchor_window`. An
+    empty window -- a series shorter than the refold window, or a gap in
+    recorded statistics there -- has no row to anchor on, so the whole series
+    is re-folded from zero. Folding from zero is the correct fallback: a
+    partial fold needs an anchor sum paired with the matching anchor start, and
+    no row supplies that pair. Anchoring on the last recorded row instead would
+    skip every bucket in the trailing window, silently dropping late upstream
+    corrections.
+
+    Returns:
+        The anchor to fold onto.
+    """
+    if not window_rows:
+        return COLD_START
+    row = max(window_rows, key=itemgetter("start"))
+    return Anchor(start=_utc_from_epoch(row["start"]), sum=row["sum"] or 0.0)
+
+
+def clear(hass: HomeAssistant, entry: WaterSmartConfigEntry) -> None:
+    """Clear the external statistics series for an entry.
+
+    ``async_clear_statistics`` schedules work on the recorder thread and
+    returns immediately, so there is nothing to await.
+    """
+    get_instance(hass).async_clear_statistics([statistic_id_for(entry.entry_id)])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,8 +52,15 @@ def fixture_loader():
 
 
 @pytest.fixture(autouse=True)
-def auto_enable_custom_integrations(enable_custom_integrations):
-    """Enable custom integrations."""
+def auto_enable_custom_integrations(recorder_mock, enable_custom_integrations):
+    """Enable custom integrations, with the recorder set up first.
+
+    ``recorder_mock`` is ordered before ``enable_custom_integrations`` (which
+    pulls in ``hass``) so the recorder's fixtures initialize ahead of the hass
+    fixture, as they require. The integration declares ``recorder`` as a
+    manifest dependency, so HA refuses to set it up without the recorder
+    present.
+    """
     return
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,11 +1,33 @@
 """Test component setup."""
 
+from unittest.mock import MagicMock, patch
+
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
+import pytest
 
 from custom_components.watersmart.const import DOMAIN
+from custom_components.watersmart.statistics import statistic_id_for
 
 
 async def test_async_setup(hass: HomeAssistant):
     """Test the component gets setup."""
     assert await async_setup_component(hass, DOMAIN, {}) is True
+
+
+@pytest.mark.asyncio
+async def test_remove_entry_clears_statistics(hass: HomeAssistant, init_integration):
+    """Removing the config entry clears the external statistics series."""
+    entry = init_integration
+
+    mock_recorder = MagicMock()
+    with patch(
+        "custom_components.watersmart.statistics.get_instance",
+        return_value=mock_recorder,
+    ):
+        await hass.config_entries.async_remove(entry.entry_id)
+        await hass.async_block_till_done()
+
+    mock_recorder.async_clear_statistics.assert_called_once_with(
+        [statistic_id_for(entry.entry_id)]
+    )

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -1,0 +1,563 @@
+"""Tests for the WaterSmart long-term-statistics module."""
+
+import datetime as dt
+from typing import Self
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.components.recorder.db_schema import StatisticsMeta
+from homeassistant.components.recorder.models import StatisticMeanType
+from homeassistant.const import UnitOfVolume
+from homeassistant.core import HomeAssistant
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.watersmart.client import UsageRecord
+from custom_components.watersmart.const import DOMAIN
+from custom_components.watersmart.statistics import (
+    ANCHOR_LOOKBACK,
+    COLD_START,
+    REFOLD_WINDOW,
+    Anchor,
+    anchor_window,
+    bucket_records,
+    clear,
+    fold_cumulative,
+    metadata_for,
+    select_anchor,
+    statistic_id_for,
+)
+
+_STATISTICS = "custom_components.watersmart.statistics"
+
+
+def test_statistic_id_for_returns_prefixed_entry_id():
+    assert statistic_id_for("abc123") == "watersmart:abc123"
+
+
+def test_statistic_id_for_lowercases_ulid_entry_id():
+    # HA config-entry ids are uppercase ULIDs; HA requires statistic_ids to be
+    # slugs (lowercase). Lowercasing a Crockford-base32 ULID is lossless.
+    assert (
+        statistic_id_for("01KS0XG47WMNF3GZYEPDT2A76F")
+        == "watersmart:01ks0xg47wmnf3gzyepdt2a76f"
+    )
+
+
+def test_metadata_for_has_expected_shape():
+    meta = metadata_for("abc123", "bendoregon")
+    assert meta["statistic_id"] == "watersmart:abc123"
+    assert meta["source"] == "watersmart"
+    assert meta["name"] == "Water consumption (bendoregon)"
+    assert meta["unit_of_measurement"] == UnitOfVolume.GALLONS
+    assert meta["has_sum"] is True
+    assert meta["mean_type"] is StatisticMeanType.NONE
+
+
+def test_metadata_for_sets_unit_class_where_the_recorder_accepts_it():
+    with patch(f"{_STATISTICS}._SUPPORTS_UNIT_CLASS", new=True):
+        meta = metadata_for("abc123", "bendoregon")
+    assert meta["unit_class"] == "volume"
+
+
+def test_metadata_for_omits_unit_class_where_the_recorder_lacks_it():
+    # Before HA 2025.11.0, `StatisticsMeta(**metadata)` raises TypeError on it.
+    with patch(f"{_STATISTICS}._SUPPORTS_UNIT_CLASS", new=False):
+        meta = metadata_for("abc123", "bendoregon")
+    assert "unit_class" not in meta
+
+
+def test_metadata_for_is_accepted_by_the_recorder_schema():
+    # The import tests mock `async_add_external_statistics`, so nothing else
+    # checks the metadata against the recorder. `StatisticsMeta.from_meta`
+    # splats it into the ORM model, where an unsupported key is a TypeError.
+    # Left unpatched so the version probe is checked against the installed
+    # recorder, whichever version that is.
+    row = StatisticsMeta.from_meta(metadata_for("abc123", "bendoregon"))
+    assert row.statistic_id == "watersmart:abc123"
+
+
+def _utc(year, month, day, hour):
+    return dt.datetime(year, month, day, hour, tzinfo=dt.UTC)
+
+
+def _ts(year, month, day, hour, minute=0):
+    return int(dt.datetime(year, month, day, hour, minute, tzinfo=dt.UTC).timestamp())
+
+
+def _record(read_datetime: int, gallons: float | None) -> UsageRecord:
+    """Build a usage record; ``leak_gallons``/``flags`` are irrelevant here."""
+    return {
+        "read_datetime": read_datetime,
+        "gallons": gallons,
+        "leak_gallons": 0,
+        "flags": None,
+    }
+
+
+def _stat_row(start: dt.datetime, **values: float) -> dict[str, float]:
+    """A recorder statistics row as HA returns it.
+
+    HA's recorder query API (``get_last_statistics``,
+    ``statistics_during_period``) returns ``StatisticsRow`` with ``start`` as a
+    float epoch timestamp -- even though the write side takes a ``datetime``.
+    Doubles must use that representation or they hide read-side type bugs.
+    """
+    return {"start": start.timestamp(), **values}
+
+
+def test_bucket_records_empty_input():
+    assert bucket_records([]) == []
+
+
+def test_bucket_records_simple_pass_through():
+    records = [
+        _record(_ts(2026, 5, 1, 0), 1.0),
+        _record(_ts(2026, 5, 1, 1), 2.0),
+    ]
+    assert bucket_records(records) == [
+        (_utc(2026, 5, 1, 0), 1.0),
+        (_utc(2026, 5, 1, 1), 2.0),
+    ]
+
+
+def test_bucket_records_drops_none_gallons():
+    records = [
+        _record(_ts(2026, 5, 1, 0), 1.0),
+        _record(_ts(2026, 5, 1, 1), None),
+        _record(_ts(2026, 5, 1, 2), 3.0),
+    ]
+    assert bucket_records(records) == [
+        (_utc(2026, 5, 1, 0), 1.0),
+        (_utc(2026, 5, 1, 2), 3.0),
+    ]
+
+
+def test_bucket_records_sums_duplicate_hour():
+    # Sub-hour timestamp jitter can land two readings in the same UTC hour.
+    records = [
+        _record(_ts(2026, 5, 1, 0, 0), 1.0),
+        _record(_ts(2026, 5, 1, 0, 30), 2.5),
+    ]
+    assert bucket_records(records) == [(_utc(2026, 5, 1, 0), 3.5)]
+
+
+def test_bucket_records_sorts_chronologically():
+    records = [
+        _record(_ts(2026, 5, 1, 2), 3.0),
+        _record(_ts(2026, 5, 1, 0), 1.0),
+        _record(_ts(2026, 5, 1, 1), 2.0),
+    ]
+    assert bucket_records(records) == [
+        (_utc(2026, 5, 1, 0), 1.0),
+        (_utc(2026, 5, 1, 1), 2.0),
+        (_utc(2026, 5, 1, 2), 3.0),
+    ]
+
+
+def test_fold_cumulative_empty():
+    assert fold_cumulative([], COLD_START) == []
+
+
+def test_fold_cumulative_from_zero():
+    buckets = [
+        (_utc(2026, 5, 1, 0), 1.0),
+        (_utc(2026, 5, 1, 1), 2.0),
+        (_utc(2026, 5, 1, 2), 3.0),
+    ]
+    rows = fold_cumulative(buckets, COLD_START)
+    assert [r["start"] for r in rows] == [b[0] for b in buckets]
+    assert [r["sum"] for r in rows] == [1.0, 3.0, 6.0]
+    # state is each hour's own gallons (per-period), not the running cumulative.
+    assert [r["state"] for r in rows] == [1.0, 2.0, 3.0]
+
+
+def test_fold_cumulative_continues_from_anchor_sum():
+    buckets = [
+        (_utc(2026, 5, 1, 3), 1.0),
+        (_utc(2026, 5, 1, 4), 2.0),
+    ]
+    rows = fold_cumulative(buckets, Anchor(start=_utc(2026, 5, 1, 2), sum=100.0))
+    assert [r["sum"] for r in rows] == [101.0, 103.0]
+    # state is the per-hour gallons; only sum carries the anchor's cumulative.
+    assert [r["state"] for r in rows] == [1.0, 2.0]
+
+
+def test_fold_cumulative_drops_buckets_at_or_before_anchor():
+    buckets = [
+        (_utc(2026, 5, 1, 1), 1.0),
+        (_utc(2026, 5, 1, 2), 2.0),
+        (_utc(2026, 5, 1, 3), 3.0),
+    ]
+    rows = fold_cumulative(buckets, Anchor(start=_utc(2026, 5, 1, 2), sum=10.0))
+    assert [r["start"] for r in rows] == [_utc(2026, 5, 1, 3)]
+    assert [r["sum"] for r in rows] == [13.0]
+
+
+def test_anchor_window_spans_lookback_before_the_refold_cutoff():
+    last_start = _utc(2026, 5, 10, 0)
+    window_start, window_end = anchor_window(_stat_row(last_start))
+    cutoff = last_start - REFOLD_WINDOW
+    assert window_start == cutoff - ANCHOR_LOOKBACK
+    assert window_end == cutoff + dt.timedelta(hours=1)
+
+
+def test_select_anchor_prefers_latest_window_row():
+    latest = _utc(2026, 5, 8, 1)
+    window = [
+        _stat_row(_utc(2026, 5, 8, 0), sum=100.0),
+        _stat_row(latest, sum=110.0),
+    ]
+    assert select_anchor(window) == Anchor(start=latest, sum=110.0)
+
+
+def test_select_anchor_cold_starts_when_window_empty():
+    # No row in the anchor window (series younger than the refold window, or a
+    # recorded gap): re-fold the whole series from zero rather than appending.
+    assert select_anchor([]) == COLD_START
+
+
+@pytest.mark.asyncio
+async def test_clear_calls_recorder_with_statistic_id(  # noqa: RUF029
+    hass: HomeAssistant,
+):
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"host": "test", "username": "u@example.com", "password": "x"},
+        entry_id="entry-id-123",
+    )
+    mock_recorder = MagicMock()
+    with patch(
+        "custom_components.watersmart.statistics.get_instance",
+        return_value=mock_recorder,
+    ):
+        clear(hass, entry)
+
+    mock_recorder.async_clear_statistics.assert_called_once_with(
+        ["watersmart:entry-id-123"]
+    )
+
+
+class _Recorder:
+    """Patches the coordinator's recorder calls for an integration test.
+
+    The recorder isn't set up in tests, so `get_instance` would raise. The
+    coordinator dispatches `get_last_statistics` and `statistics_during_period`
+    through the executor; this stub runs them inline so the patched callables
+    are what actually run. `async_add_external_statistics` is sync (the
+    `async_` prefix is HA's "safe-on-event-loop" convention, not "returns a
+    coroutine"), so it is a plain `MagicMock`.
+    """
+
+    def __init__(
+        self,
+        *,
+        last_statistics: dict | None = None,
+        during_period: dict | None = None,
+        add_side_effect: Exception | None = None,
+        query_side_effect: Exception | None = None,
+    ) -> None:
+        self.add_external = MagicMock(side_effect=add_side_effect, return_value=None)
+        self.get_last = MagicMock(
+            side_effect=query_side_effect, return_value=last_statistics or {}
+        )
+        self.stats_during = MagicMock(return_value=during_period or {})
+
+    @property
+    def imported_rows(self) -> list:
+        """The rows passed to the most recent recorder write."""
+        return list(self.add_external.call_args.args[2])
+
+    def __enter__(self) -> Self:
+        inline = MagicMock()
+        inline.async_add_executor_job = AsyncMock(
+            side_effect=lambda func, *args, **kwargs: func(*args, **kwargs)
+        )
+        prefix = "custom_components.watersmart.coordinator"
+        self._patches = [
+            patch(f"{prefix}.get_instance", return_value=inline),
+            patch(f"{prefix}.async_add_external_statistics", self.add_external),
+            patch(f"{prefix}.get_last_statistics", self.get_last),
+            patch(f"{prefix}.statistics_during_period", self.stats_during),
+        ]
+        for p in self._patches:
+            p.start()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        for p in self._patches:
+            p.stop()
+
+
+def _coordinator(hass: HomeAssistant):
+    """Return the coordinator of the single configured WaterSmart entry."""
+    return hass.config_entries.async_entries(DOMAIN)[0].runtime_data.coordinator
+
+
+async def _refresh(hass: HomeAssistant) -> None:
+    """Trigger a coordinator refresh and wait for it to settle."""
+    await _coordinator(hass).async_refresh()
+    await hass.async_block_till_done()
+
+
+@pytest.fixture
+def client_hourly_data_long(mock_watersmart_client):
+    """Extend the default fixture to 100 hours so the 48h re-import window has room."""
+    hourly = mock_watersmart_client.async_get_hourly_data.return_value
+    for _ in range(96):
+        last_time = dt.datetime.fromtimestamp(hourly[-1]["read_datetime"], tz=dt.UTC)
+        next_time = int((last_time + dt.timedelta(hours=1)).timestamp())
+        hourly.append(_record(next_time, 1.0))
+    mock_watersmart_client.async_get_hourly_data.return_value = hourly
+
+
+@pytest.fixture
+def warm_anchor(
+    hass: HomeAssistant,
+    client_hourly_data_long,
+    mock_watersmart_client,
+    init_integration,
+):
+    """Recorder state for a warm refresh anchored 48h before the last bucket.
+
+    Extends the client series to 100 hours so the 48h window has room, then
+    yields ``(recorder_kwargs, anchor, last_sum)`` where ``anchor`` is the
+    ``(start, sum)`` the trailing window folds onto and ``last_sum`` is the
+    cumulative sum of the whole series.
+    """
+    records = mock_watersmart_client.async_get_hourly_data.return_value
+    last_start = dt.datetime.fromtimestamp(
+        records[-1]["read_datetime"], tz=dt.UTC
+    ).replace(minute=0, second=0, microsecond=0)
+    last_sum = sum(r["gallons"] for r in records if r["gallons"] is not None)
+    anchor_start = last_start - REFOLD_WINDOW
+    anchor_sum = sum(
+        r["gallons"]
+        for r in records
+        if r["gallons"] is not None
+        and dt.datetime.fromtimestamp(r["read_datetime"], tz=dt.UTC).replace(
+            minute=0, second=0, microsecond=0
+        )
+        <= anchor_start
+    )
+
+    statistic_id = statistic_id_for(_coordinator(hass).entry_id)
+    recorder_kwargs = {
+        "last_statistics": {statistic_id: [_stat_row(last_start, sum=last_sum)]},
+        "during_period": {
+            statistic_id: [_stat_row(anchor_start, sum=anchor_sum)],
+        },
+    }
+    return recorder_kwargs, (anchor_start, anchor_sum), last_sum
+
+
+@pytest.mark.asyncio
+async def test_cold_start_imports_full_history(
+    hass: HomeAssistant,
+    mock_watersmart_client,
+    init_integration,  # fixture sets up the entry
+):
+    """On cold start, all hours from the API are imported with monotonic sum."""
+
+    expected_records = mock_watersmart_client.async_get_hourly_data.return_value
+
+    with _Recorder() as recorder:  # empty last_statistics => cold start
+        await _refresh(hass)
+
+    recorder.add_external.assert_called_once()
+    _hass_arg, metadata, _statistics = recorder.add_external.call_args.args
+    assert metadata["source"] == "watersmart"
+    rows = recorder.imported_rows
+    assert len(rows) == len(expected_records)
+    # Monotonic non-decreasing sum starting from the first hour's gallons.
+    assert rows[0]["sum"] == expected_records[0]["gallons"]
+    expected_total = sum(
+        r["gallons"] for r in expected_records if r["gallons"] is not None
+    )
+    assert rows[-1]["sum"] == pytest.approx(expected_total)
+
+
+@pytest.mark.asyncio
+async def test_warm_path_reimports_last_48h_only(
+    hass: HomeAssistant,
+    warm_anchor: tuple[dict, tuple[dt.datetime, float], float],
+):
+    """On a warm refresh, only the last 48h are re-folded against the anchor."""
+    recorder_kwargs, (anchor_start, anchor_sum), last_sum = warm_anchor
+
+    with _Recorder(**recorder_kwargs) as recorder:
+        await _refresh(hass)
+
+    recorder.add_external.assert_called_once()
+    rows = recorder.imported_rows
+    assert len(rows) == 48
+    assert rows[0]["sum"] == pytest.approx(anchor_sum + 1.0)
+    assert rows[-1]["sum"] == pytest.approx(last_sum)
+
+    # The re-import hinges on looking the anchor up over the ±1h-padded window,
+    # so assert the span actually passed to statistics_during_period rather
+    # than trusting the resulting row count (the mock ignores its time args).
+    last_start = anchor_start + REFOLD_WINDOW
+    _hass, window_start, window_end, *_ = recorder.stats_during.call_args.args
+    assert window_start == last_start - REFOLD_WINDOW - ANCHOR_LOOKBACK
+    assert window_end == last_start - REFOLD_WINDOW + dt.timedelta(hours=1)
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("client_hourly_data_long")
+async def test_warm_path_no_new_buckets_does_not_write(
+    hass: HomeAssistant,
+    mock_watersmart_client,
+    init_integration,
+):
+    """If no buckets are newer than the anchor, the recorder isn't called."""
+
+    records = mock_watersmart_client.async_get_hourly_data.return_value
+    last_start = dt.datetime.fromtimestamp(
+        records[-1]["read_datetime"], tz=dt.UTC
+    ).replace(minute=0, second=0, microsecond=0)
+    anchor_sum = sum(r["gallons"] for r in records if r["gallons"] is not None)
+
+    statistic_id = statistic_id_for(_coordinator(hass).entry_id)
+    with _Recorder(
+        last_statistics={statistic_id: [_stat_row(last_start, sum=anchor_sum)]},
+        during_period={statistic_id: [_stat_row(last_start, sum=anchor_sum)]},
+    ) as recorder:
+        await _refresh(hass)
+
+    recorder.add_external.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_warm_path_refolds_from_zero_when_anchor_window_empty(
+    hass: HomeAssistant,
+    mock_watersmart_client,
+    init_integration,
+):
+    """A series younger than the refold window has no anchor row to fold onto.
+
+    The warm refresh re-folds the whole series from zero rather than appending
+    only newer buckets, so a restated historical hour is still corrected.
+    """
+    records = mock_watersmart_client.async_get_hourly_data.return_value
+    records[1]["gallons"] = 99.0  # a historical hour restated by upstream
+    last_start = dt.datetime.fromtimestamp(
+        records[-1]["read_datetime"], tz=dt.UTC
+    ).replace(minute=0, second=0, microsecond=0)
+    restated_start = dt.datetime.fromtimestamp(
+        records[1]["read_datetime"], tz=dt.UTC
+    ).replace(minute=0, second=0, microsecond=0)
+
+    statistic_id = statistic_id_for(_coordinator(hass).entry_id)
+    # A prior row exists, but the anchor window (a refold-window back) is empty.
+    with _Recorder(
+        last_statistics={statistic_id: [_stat_row(last_start, sum=500.0)]},
+        during_period={},
+    ) as recorder:
+        await _refresh(hass)
+
+    recorder.add_external.assert_called_once()
+    rows = recorder.imported_rows
+    assert len(rows) == len(records)
+    assert rows[0]["sum"] == pytest.approx(records[0]["gallons"])
+    restated = next(r for r in rows if r["start"] == restated_start)
+    assert restated["sum"] == pytest.approx(records[0]["gallons"] + 99.0)
+
+
+@pytest.mark.asyncio
+async def test_recorder_failure_is_swallowed(
+    hass: HomeAssistant,
+    mock_watersmart_client,
+    init_integration,
+    caplog,
+):
+    """A recorder failure inside _insert_statistics must not fail the refresh."""
+
+    # Empty last_statistics => cold start reaches async_add_external_statistics.
+    with _Recorder(add_side_effect=RuntimeError("recorder down")):
+        await _refresh(hass)
+
+    assert _coordinator(hass).last_update_success is True
+    assert "Failed to write statistics" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_recorder_query_failure_is_swallowed(
+    hass: HomeAssistant,
+    mock_watersmart_client,
+    init_integration,
+    caplog,
+):
+    """A failing recorder query must not fail the refresh, nor write rows."""
+    with _Recorder(query_side_effect=RuntimeError("recorder down")) as recorder:
+        await _refresh(hass)
+
+    assert _coordinator(hass).last_update_success is True
+    assert "Failed to read last statistics" in caplog.text
+    recorder.add_external.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_none_gallons_mid_series_skipped(
+    hass: HomeAssistant,
+    mock_watersmart_client,
+    init_integration,
+):
+    """A None-gallons record mid-series is skipped; surrounding rows import."""
+    records = mock_watersmart_client.async_get_hourly_data.return_value
+    records[1]["gallons"] = None
+
+    with _Recorder() as recorder:
+        await _refresh(hass)
+
+    assert len(recorder.imported_rows) == len(records) - 1
+
+
+@pytest.mark.asyncio
+async def test_empty_hourly_response_no_write(
+    hass: HomeAssistant,
+    mock_watersmart_client,
+    init_integration,
+):
+    """If the API returns an empty list, no recorder write happens."""
+    mock_watersmart_client.async_get_hourly_data.return_value = []
+
+    with _Recorder() as recorder:
+        await _refresh(hass)
+
+    recorder.add_external.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("client_hourly_data_long")
+async def test_restated_historical_hour_within_48h_upserts(
+    hass: HomeAssistant,
+    mock_watersmart_client,
+    init_integration,
+):
+    """A restated value within the 48h window flows through to the recorder."""
+    records = mock_watersmart_client.async_get_hourly_data.return_value
+    last_start = dt.datetime.fromtimestamp(
+        records[-1]["read_datetime"], tz=dt.UTC
+    ).replace(minute=0, second=0, microsecond=0)
+    target_ts = int((last_start - dt.timedelta(hours=24)).timestamp())
+    for r in records:
+        if r["read_datetime"] == target_ts:
+            r["gallons"] = 99.0
+            break
+
+    anchor_start = last_start - REFOLD_WINDOW
+
+    statistic_id = statistic_id_for(_coordinator(hass).entry_id)
+    with _Recorder(
+        last_statistics={statistic_id: [_stat_row(last_start, sum=0.0)]},
+        during_period={statistic_id: [_stat_row(anchor_start, sum=0.0)]},
+    ) as recorder:
+        await _refresh(hass)
+
+    recorder.add_external.assert_called_once()
+    restated = [
+        r
+        for r in recorder.imported_rows
+        if r["start"] == last_start - dt.timedelta(hours=24)
+    ]
+    assert len(restated) == 1


### PR DESCRIPTION
## Summary

Imports the hourly water-usage series into Home Assistant's long-term statistics so it surfaces in the Energy dashboard's water-consumption section, labeled `Water consumption (<host>)`.

This implements the request in #6, and revives #26, which stalled and was closed by the stale bot. The one thing asked for on #26 — "let's try to get all of those made into automated test cases" — is done here: cold start, warm refresh, the trailing-window boundary, late revisions, and recorder failures all have tests. Thanks to @strulock for the original; the design differs in a few places, noted below.

## How it works

Home Assistant records a consumption series as a running total: each hourly row holds that hour's own usage and the cumulative total of every hour before it. WaterSmart reports each hour on its own, so the values are accumulated before the recorder takes them. The coordinator drives that on each refresh:

- **Cold start** (no recorded rows): imports the entire history WaterSmart exposes for the account, accumulating from zero.
- **Warm refresh**: resumes from the most recent recorded hour old enough to have settled — roughly two days back, since WaterSmart keeps revising more recent hours — and re-imports every hour after it. Revisions inside that window are picked up; older rows are left untouched.

Records are grouped by UTC hour and summed within an hour, since sub-hour timestamp jitter in the source data can place two readings in the same hour.

The `statistic_id` is derived from the config entry's internal id (`watersmart:<entry_id>`, lowercased) rather than the host or username, so re-authenticating or editing either one keeps writing to the same series instead of stranding it and starting a new one. Removing the config entry clears the external series. Recorder failures are caught and logged rather than propagated, so a statistics error cannot mask the sensor data a refresh already produced.

## Changes

- `custom_components/watersmart/statistics.py` (new): accumulate the hourly series into cumulative-sum statistics rows and upsert them into the recorder.
- `custom_components/watersmart/coordinator.py`: drive the import on refresh (full backfill on a cold start, trailing-window re-import afterwards).
- `custom_components/watersmart/__init__.py`: clear the external series on entry removal.
- `custom_components/watersmart/manifest.json`: add `recorder` to `dependencies`.
- `README.md`: document the Energy dashboard section and its limitations.
- `tests/test_statistics.py` (new) and `tests/test_init.py`: cover the cold/warm import paths.

## `unit_class` and the Home Assistant version

`StatisticMetaData` has a `unit_class` field naming the converter the recorder should use — here `VolumeConverter.UNIT_CLASS` (`"volume"`). Setting it lets Home Assistant render the series in the user's preferred volume unit instead of pinning it to gallons.

It can't be set unconditionally. `unit_class` arrived in Home Assistant **2025.11.0** (both the `StatisticMetaData` key and the `StatisticsMeta` ORM column). This repo pins `pytest-homeassistant-custom-component==0.13.252`, which is Home Assistant 2025.6.1, and on that version the recorder builds its metadata row with `StatisticsMeta(**metadata)` — so the key raises `TypeError: 'unit_class' is an invalid keyword argument for StatisticsMeta`. Since `_write_statistics` catches and logs recorder errors, that failure would be silent: no crash, and no statistics. (`VolumeConverter.UNIT_CLASS` itself long predates 2025.11.0, so the constraint is the metadata field; both are needed.)

Rather than raise this integration's minimum Home Assistant version, `metadata_for` probes for the field and sets it only where the recorder accepts it:

```python
_SUPPORTS_UNIT_CLASS = "unit_class" in StatisticMetaData.__annotations__
```

Newer installations keep the unit conversion; older ones keep working. Both arms are covered by tests, and checked against real recorders — on 2025.6.1 (this repo's pin) the field is omitted; on 2025.11.0 the recorder stores `unit_class='volume'`.

The import tests mock `async_add_external_statistics`, so none of them exercise the recorder's own schema. `test_metadata_for_is_accepted_by_the_recorder_schema` covers that: it builds the metadata through `StatisticsMeta.from_meta`, letting the installed recorder decide whether the metadata is valid — including whether it accepts `unit_class` on the version under test.

If you'd rather raise the floor, bumping the test pin to `pytest-homeassistant-custom-component==0.13.294` (Home Assistant 2025.11.0) or newer would let the probe and its two tests be deleted in favor of setting the field outright. Happy to follow up with that if you bump it — it's your call on what minimum this integration should support, and nothing here depends on the answer.

## Differences from #26

- `statistic_id` is keyed on the config entry id, not the hostname, so re-auth and host edits don't strand the series.
- Records are grouped by UTC hour and summed, rather than one statistics row per raw record.
- Warm refreshes re-import the trailing window instead of appending only strictly-newer records, so the revisions WaterSmart makes to recent hours are picked up.
- `recorder` is a hard `dependencies` entry rather than `after_dependencies`, matching how core integrations that write external statistics declare it (`opower`, `tibber`).
- The external series is cleared when the config entry is removed.
- No additional sensor entity: the Energy dashboard selects the external statistic directly. #26's `Total usage` sensor could be added on top if you want a live cumulative entity — say the word.

## Testing

Beyond the automated tests, this has been running against the Bend, Oregon utility (`bendoregon`) on Home Assistant 2026.7.1, with a backfilled series of ~61k hourly rows feeding the Energy dashboard's water section.

## Known limitations

Historical corrections WaterSmart emits more than ~48h after the fact are not picked up automatically. Removing and re-adding the config entry triggers a fresh full backfill.

## Note

Authored by an automated agent (Claude Code) working on my behalf, reviewed and submitted by me.
