### PR TITLE
fix: read read_datetime as local wall clock in statistics

### DIFF
--- a/custom_components/watersmart/statistics.py
+++ b/custom_components/watersmart/statistics.py
@@ -31,6 +31,7 @@ from homeassistant.components.recorder.models import (
 )
 from homeassistant.const import UnitOfVolume
 from homeassistant.core import HomeAssistant
+from homeassistant.util.dt import get_default_time_zone
 from homeassistant.util.unit_conversion import VolumeConverter
 
 from .client import UsageRecord
@@ -53,16 +54,42 @@ _SUPPORTS_UNIT_CLASS = "unit_class" in StatisticMetaData.__annotations__
 
 
 def _utc_from_epoch(timestamp: float) -> dt.datetime:
-    """Interpret an epoch timestamp as a UTC datetime.
+    """Interpret a recorder epoch timestamp as a UTC datetime.
 
-    Both source representations the import consumes -- the client's
-    ``read_datetime`` and the recorder's ``StatisticsRow["start"]`` -- carry
-    times as epoch seconds; the fold works in UTC datetimes throughout.
+    ``StatisticsRow["start"]`` is a true epoch: the recorder stores the instant.
+    The fold works in UTC datetimes throughout.
+
+    This is *not* how the client's ``read_datetime`` is read -- see
+    :func:`_hour_start_utc`.
 
     Returns:
         The timestamp as a timezone-aware UTC datetime.
     """
     return dt.datetime.fromtimestamp(timestamp, tz=dt.UTC)
+
+
+def _hour_start_utc(read_datetime: float) -> dt.datetime:
+    """Convert a reading's ``read_datetime`` to the UTC instant its hour begins.
+
+    ``read_datetime`` is not a true epoch. The portal encodes the utility's
+    local wall clock as though it were UTC, so the number's digits *are* local
+    time and the value has to be relabeled rather than converted -- the same
+    reading ``coordinator._from_timestamp`` applies.
+
+    The raw series shows this directly: reads are 3600s apart except across DST,
+    where an hour is skipped each spring-forward and repeated each fall-back. A
+    true epoch series of hourly reads would be uniformly spaced.
+
+    Truncation happens in local time, before conversion, so an hour bucket is
+    the utility's hour on utilities whose offset is not a whole number of hours.
+
+    Returns:
+        The start of the reading's hour, as a timezone-aware UTC datetime.
+    """
+    local = dt.datetime.fromtimestamp(read_datetime, tz=dt.UTC).replace(
+        tzinfo=get_default_time_zone()
+    )
+    return local.replace(minute=0, second=0, microsecond=0).astimezone(dt.UTC)
 
 
 def statistic_id_for(entry_id: str) -> str:
@@ -104,11 +131,11 @@ def metadata_for(entry_id: str, hostname: str) -> StatisticMetaData:
 def bucket_records(
     records: Iterable[UsageRecord],
 ) -> list[tuple[dt.datetime, float]]:
-    """Group records by UTC hour.
+    """Group records by the hour they were read in, keyed by UTC instant.
 
     Drops records with ``gallons is None``; sums multiple records that fall
-    within the same UTC hour (sub-hour timestamp jitter in the source data can
-    place two readings in one hour); returns the result sorted chronologically.
+    within the same hour (sub-hour timestamp jitter in the source data can place
+    two readings in one hour); returns the result sorted chronologically.
 
     Returns:
         ``(hour_start_utc, gallons)`` pairs sorted chronologically.
@@ -118,9 +145,7 @@ def bucket_records(
         gallons = record["gallons"]
         if gallons is None:
             continue
-        start = _utc_from_epoch(record["read_datetime"]).replace(
-            minute=0, second=0, microsecond=0
-        )
+        start = _hour_start_utc(record["read_datetime"])
         buckets[start] = buckets.get(start, 0.0) + gallons
     return sorted(buckets.items())
 

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -8,6 +8,7 @@ from homeassistant.components.recorder.db_schema import StatisticsMeta
 from homeassistant.components.recorder.models import StatisticMeanType
 from homeassistant.const import UnitOfVolume
 from homeassistant.core import HomeAssistant
+from homeassistant.util.dt import get_default_time_zone
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -77,11 +78,41 @@ def test_metadata_for_is_accepted_by_the_recorder_schema():
 
 
 def _utc(year, month, day, hour):
+    """A UTC instant, as the recorder stores and returns them."""
     return dt.datetime(year, month, day, hour, tzinfo=dt.UTC)
 
 
+def _local(year, month, day, hour):
+    """The UTC instant at a given *local* wall-clock hour.
+
+    Buckets are keyed by UTC instants, but the hour a reading belongs to is the
+    utility's local hour, so this is what ``bucket_records`` returns.
+    """
+    return dt.datetime(
+        year, month, day, hour, tzinfo=get_default_time_zone()
+    ).astimezone(dt.UTC)
+
+
 def _ts(year, month, day, hour, minute=0):
+    """A WaterSmart ``read_datetime``.
+
+    The portal encodes the utility's local wall clock as though it were UTC, so
+    the digits passed here are *local* time, not UTC (see
+    ``statistics._hour_start_utc``).
+    """
     return int(dt.datetime(year, month, day, hour, minute, tzinfo=dt.UTC).timestamp())
+
+
+def _bucket_start(read_datetime: float) -> dt.datetime:
+    """The UTC instant a reading's hour bucket is keyed by.
+
+    ``read_datetime`` carries local wall clock, so the hour is truncated in
+    local time and then converted.
+    """
+    local = dt.datetime.fromtimestamp(read_datetime, tz=dt.UTC).replace(
+        tzinfo=get_default_time_zone()
+    )
+    return local.replace(minute=0, second=0, microsecond=0).astimezone(dt.UTC)
 
 
 def _record(read_datetime: int, gallons: float | None) -> UsageRecord:
@@ -115,8 +146,8 @@ def test_bucket_records_simple_pass_through():
         _record(_ts(2026, 5, 1, 1), 2.0),
     ]
     assert bucket_records(records) == [
-        (_utc(2026, 5, 1, 0), 1.0),
-        (_utc(2026, 5, 1, 1), 2.0),
+        (_local(2026, 5, 1, 0), 1.0),
+        (_local(2026, 5, 1, 1), 2.0),
     ]
 
 
@@ -127,18 +158,18 @@ def test_bucket_records_drops_none_gallons():
         _record(_ts(2026, 5, 1, 2), 3.0),
     ]
     assert bucket_records(records) == [
-        (_utc(2026, 5, 1, 0), 1.0),
-        (_utc(2026, 5, 1, 2), 3.0),
+        (_local(2026, 5, 1, 0), 1.0),
+        (_local(2026, 5, 1, 2), 3.0),
     ]
 
 
 def test_bucket_records_sums_duplicate_hour():
-    # Sub-hour timestamp jitter can land two readings in the same UTC hour.
+    # Sub-hour timestamp jitter can land two readings in the same hour.
     records = [
         _record(_ts(2026, 5, 1, 0, 0), 1.0),
         _record(_ts(2026, 5, 1, 0, 30), 2.5),
     ]
-    assert bucket_records(records) == [(_utc(2026, 5, 1, 0), 3.5)]
+    assert bucket_records(records) == [(_local(2026, 5, 1, 0), 3.5)]
 
 
 def test_bucket_records_sorts_chronologically():
@@ -148,10 +179,47 @@ def test_bucket_records_sorts_chronologically():
         _record(_ts(2026, 5, 1, 1), 2.0),
     ]
     assert bucket_records(records) == [
-        (_utc(2026, 5, 1, 0), 1.0),
-        (_utc(2026, 5, 1, 1), 2.0),
-        (_utc(2026, 5, 1, 2), 3.0),
+        (_local(2026, 5, 1, 0), 1.0),
+        (_local(2026, 5, 1, 1), 2.0),
+        (_local(2026, 5, 1, 2), 3.0),
     ]
+
+
+def test_bucket_records_reads_timestamps_as_local_wall_clock():
+    # The portal's `read_datetime` digits are the utility's local time, so a
+    # reading labelled midnight belongs to the UTC hour midnight *local* falls
+    # in -- not to 00:00 UTC.
+    (start, _gallons) = bucket_records([_record(_ts(2026, 5, 1, 0), 1.0)])[0]
+    assert start == _local(2026, 5, 1, 0)
+    assert start != _utc(2026, 5, 1, 0)
+
+
+def test_bucket_records_spans_the_spring_forward_gap():
+    # Local time skips 02:00 on a spring-forward, and the portal's series skips
+    # it too -- proof the timestamps carry wall clock rather than instants.
+    # Reading them as local keeps the buckets an hour apart across the seam.
+    records = [
+        _record(_ts(2026, 3, 8, 1), 1.0),
+        _record(_ts(2026, 3, 8, 3), 2.0),
+    ]
+    buckets = bucket_records(records)
+    assert [start for start, _ in buckets] == [
+        _local(2026, 3, 8, 1),
+        _local(2026, 3, 8, 3),
+    ]
+    assert buckets[1][0] - buckets[0][0] == dt.timedelta(hours=1)
+
+
+def test_bucket_records_folds_the_repeated_fall_back_hour():
+    # Fall-back repeats 01:00 local, and the portal emits both readings under
+    # the same `read_datetime`. Ambiguous wall clock resolves to the first
+    # (fold=0) occurrence, so the pair lands in one bucket rather than being
+    # spread across two hours or silently dropped.
+    records = [
+        _record(_ts(2026, 11, 1, 1), 1.0),
+        _record(_ts(2026, 11, 1, 1), 2.0),
+    ]
+    assert bucket_records(records) == [(_local(2026, 11, 1, 1), 3.0)]
 
 
 def test_fold_cumulative_empty():
@@ -325,19 +393,14 @@ def warm_anchor(
     cumulative sum of the whole series.
     """
     records = mock_watersmart_client.async_get_hourly_data.return_value
-    last_start = dt.datetime.fromtimestamp(
-        records[-1]["read_datetime"], tz=dt.UTC
-    ).replace(minute=0, second=0, microsecond=0)
+    last_start = _bucket_start(records[-1]["read_datetime"])
     last_sum = sum(r["gallons"] for r in records if r["gallons"] is not None)
     anchor_start = last_start - REFOLD_WINDOW
     anchor_sum = sum(
         r["gallons"]
         for r in records
         if r["gallons"] is not None
-        and dt.datetime.fromtimestamp(r["read_datetime"], tz=dt.UTC).replace(
-            minute=0, second=0, microsecond=0
-        )
-        <= anchor_start
+        and _bucket_start(r["read_datetime"]) <= anchor_start
     )
 
     statistic_id = statistic_id_for(_coordinator(hass).entry_id)
@@ -412,9 +475,7 @@ async def test_warm_path_no_new_buckets_does_not_write(
     """If no buckets are newer than the anchor, the recorder isn't called."""
 
     records = mock_watersmart_client.async_get_hourly_data.return_value
-    last_start = dt.datetime.fromtimestamp(
-        records[-1]["read_datetime"], tz=dt.UTC
-    ).replace(minute=0, second=0, microsecond=0)
+    last_start = _bucket_start(records[-1]["read_datetime"])
     anchor_sum = sum(r["gallons"] for r in records if r["gallons"] is not None)
 
     statistic_id = statistic_id_for(_coordinator(hass).entry_id)
@@ -440,12 +501,8 @@ async def test_warm_path_refolds_from_zero_when_anchor_window_empty(
     """
     records = mock_watersmart_client.async_get_hourly_data.return_value
     records[1]["gallons"] = 99.0  # a historical hour restated by upstream
-    last_start = dt.datetime.fromtimestamp(
-        records[-1]["read_datetime"], tz=dt.UTC
-    ).replace(minute=0, second=0, microsecond=0)
-    restated_start = dt.datetime.fromtimestamp(
-        records[1]["read_datetime"], tz=dt.UTC
-    ).replace(minute=0, second=0, microsecond=0)
+    last_start = _bucket_start(records[-1]["read_datetime"])
+    restated_start = _bucket_start(records[1]["read_datetime"])
 
     statistic_id = statistic_id_for(_coordinator(hass).entry_id)
     # A prior row exists, but the anchor window (a refold-window back) is empty.
@@ -536,9 +593,7 @@ async def test_restated_historical_hour_within_48h_upserts(
 ):
     """A restated value within the 48h window flows through to the recorder."""
     records = mock_watersmart_client.async_get_hourly_data.return_value
-    last_start = dt.datetime.fromtimestamp(
-        records[-1]["read_datetime"], tz=dt.UTC
-    ).replace(minute=0, second=0, microsecond=0)
+    last_start = _bucket_start(records[-1]["read_datetime"])
     target_ts = int((last_start - dt.timedelta(hours=24)).timestamp())
     for r in records:
         if r["read_datetime"] == target_ts:


### PR DESCRIPTION
Follow-up to #35, which I had backwards and have closed.

`read_datetime` is not a UTC epoch. The portal encodes the utility's local wall-clock time as though it were UTC, so the digits are local and the value has to be relabeled rather than converted — which is what `coordinator._from_timestamp` has always done. The statistics module I added in #34 read the same field as a true instant, so every row it wrote landed at the wrong hour, offset by the UTC offset. Confirmed against my own recorder: the series peaked at 6pm local with near-zero usage at 9pm, where the real irrigation runs at 1–2am.

The evidence is in the raw series — ~62k hourly reads off my account, 2019 to today. Consecutive `read_datetime` values sit 3600s apart everywhere except at DST transitions, where the series jumps 7200s at each spring-forward (2020-03-08, 2021-03-14, 2022-03-13, 2023-03-12, 2024-03-10 — each at a naive `01:00 → 03:00`) and repeats a timestamp at each fall-back (2019-11-03, 2020-11-01, 2021-11-07, 2022-11-06, 2023-11-05). Hourly reads on a true epoch would be uniformly spaced; only wall clock skips and repeats an hour.

The change splits the two readings, which had been sharing one helper:

- `_utc_from_epoch` now serves only the recorder's `StatisticsRow["start"]`, which *is* a genuine epoch.
- `_hour_start_utc` reads `read_datetime` as wall clock, and truncates the hour before converting so a bucket is the utility's hour on offsets that aren't a whole number of hours.

Nothing outside `statistics.py` changes, and no snapshots move — the sensor and service paths were already correct.

Tests pin the interpretation on the DST seams rather than on a plain timestamp, since that's where the two readings differ observably. The existing `bucket_records` tests had encoded the wrong assumption in both the input and the expectation, so they passed either way; they now go through a `_local` helper that names which side of the conversion each value is on.

One thing I left alone: at fall-back the portal emits both 01:00 readings under the same `read_datetime`, and relabeling resolves an ambiguous wall clock to `fold=0`, so the pair folds into the PDT hour and the PST hour reads empty. One hour a year, and the same is true of `_from_timestamp` today, so it seemed better as its own change than smuggled into this one — happy to take it either way. `test_bucket_records_folds_the_repeated_fall_back_hour` pins the current behaviour so a future fix has something to move.

Worth noting for anyone already running v0.1.10: existing statistics rows are at wrong start times, and since external statistics are keyed by start, a corrected re-import won't overwrite them. It takes a `recorder.clear_statistics` on the `watersmart:*` id and a fresh import.

_Drafted by Claude with Seth's oversight._
