### PR TITLE
test: unload entry before recorder teardown

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,6 +64,32 @@ def auto_enable_custom_integrations(recorder_mock, enable_custom_integrations):
     return
 
 
+@pytest.fixture(autouse=True)
+async def unload_entries_before_recorder_teardown(
+    auto_enable_custom_integrations, hass: HomeAssistant
+):
+    """Stop the coordinator before the recorder disposes its database.
+
+    ``recorder_mock`` requests ``hass``, so hass is set up first and torn down
+    last: the recorder closes its SQLite connection while the loop is still live
+    and the coordinator's refresh timer is still armed. A refresh landing in that
+    window runs a recorder query against a connection being freed underneath it,
+    which segfaults the interpreter rather than raising.
+
+    Home Assistant never produces that order itself -- ``async_stop`` sets
+    ``is_stopping``, which parks scheduled refreshes, two shutdown stages before
+    the recorder closes. Unloading the entry here restores the ordering the
+    integration actually runs under.
+
+    Requesting ``auto_enable_custom_integrations`` places this fixture after the
+    recorder in setup, and so ahead of it in teardown.
+    """
+    yield
+    for entry in hass.config_entries.async_entries(DOMAIN):
+        await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
 class MockAiohttpResponse:
     def __init__(
         self,


### PR DESCRIPTION
The segfault in the pinned test job, from #36.

`recorder_mock` requests `hass`, so hass is set up first and torn down last: at
teardown the recorder closes its SQLite connection while the loop is still live
and the coordinator's refresh timer is still armed. A refresh landing in that
window queries a connection being freed underneath it and takes the interpreter
down (exit 139, inside sqlite3) instead of raising.

Home Assistant never produces that ordering -- `async_stop` sets `is_stopping`,
which parks scheduled refreshes at `update_coordinator.py:371`, two shutdown
stages before the recorder closes. So it belongs in the fixtures rather than as a
guard in the coordinator: unload the entry before the recorder tears down. An
extra `await hass.async_block_till_done()` on its own isn't enough -- that still
segfaulted 1 in 45.

Looping the suite on Linux, 45 runs each: 5 segfaults on `main`, 0 with this.
It's been there since #34, where the recorder entered the fixtures -- 0 in 30 runs
just before.

_Drafted by Claude with Seth's oversight._
